### PR TITLE
Strings get repeated when over 255 chars

### DIFF
--- a/models/Message.php
+++ b/models/Message.php
@@ -212,7 +212,7 @@ class Message extends Model
      */
     protected static function makeMessageCode($messageId)
     {
-        return strtolower(str_replace('-', '.', Str::slug($messageId)));
+        return substr(strtolower(str_replace('-', '.', Str::slug($messageId))),0 250);
     }
 
 }


### PR DESCRIPTION
I've noticed that all my strings over 255 got repeated each time I've clicked on "Scan for messages" - https://github.com/rainlab/translate-plugin/issues/27
Checking the "code" field on DB I've noticed that it's VARCHAR 255, so limiting the code to those 255 chars solved the issue and it doesn't repeat string anymore.
I thought on changing the field type on the DB but I think it makes no sense having codes that big, right?
