### PR TITLE
Added option to always prefix routes with language code

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -103,8 +103,9 @@ class Plugin extends PluginBase
     public function registerPermissions()
     {
         return [
-            'rainlab.translate.manage_locales'  => ['tab' => 'Translation', 'label' => 'rainlab.translate::lang.plugin.manage_locales'],
-            'rainlab.translate.manage_messages' => ['tab' => 'Translation', 'label' => 'rainlab.translate::lang.plugin.manage_messages']
+            'rainlab.translate.manage_locales'     => ['tab' => 'Translation', 'label' => 'rainlab.translate::lang.plugin.manage_locales'],
+            'rainlab.translate.manage_messages'    => ['tab' => 'Translation', 'label' => 'rainlab.translate::lang.plugin.manage_messages'],
+            'rainlab.translate.manage_preferences' => ['tab' => 'Translation', 'label' => 'rainlab.translate::lang.plugin.manage_preferences'],
         ];
     }
 
@@ -128,6 +129,16 @@ class Plugin extends PluginBase
                 'order'       => 551,
                 'category'    => 'rainlab.translate::lang.plugin.name',
                 'permissions' => ['rainlab.translate.manage_messages']
+            ],
+            'preferences' => [
+                'label'       => 'rainlab.translate::lang.preferences.title',
+                'description' => 'rainlab.translate::lang.preferences.description',
+                'icon'        => 'icon-cog',
+                'class'       => 'RainLab\Translate\Models\Preferences',
+                'order'       => 552,
+                'category'    => 'rainlab.translate::lang.plugin.name',
+                'permissions' => ['rainlab.translate.manage_preferences'],
+                'keywords'    => 'language translate translation',
             ]
         ];
     }

--- a/classes/Translator.php
+++ b/classes/Translator.php
@@ -4,6 +4,7 @@ use App;
 use Schema;
 use Session;
 use DbDongle;
+use Request;
 use RainLab\Translate\Models\Locale;
 
 /**
@@ -134,6 +135,28 @@ class Translator
     protected function setSessionLocale($locale)
     {
         Session::put(self::SESSION_LOCALE, $locale);
+    }
+
+    /**
+     * Returns the current path prefixed with language code.
+     *
+     * @param string $locale optional language code, default to the system default language
+     * @return string
+     */
+    public function getCurrentPathInLocale($locale = null)
+    {
+        if (is_null($locale) || !Locale::isValid($locale)) {
+            $locale = $this->defaultLocale;
+        }
+
+        $request_segments = Request::segments();
+
+        if (count($request_segments) == 0 || Locale::isValid($request_segments[0]))
+            $request_segments[0] = $locale;
+        else
+            array_unshift($request_segments, $locale);
+
+        return implode('/', $request_segments);
     }
 
 }

--- a/components/LocalePicker.php
+++ b/components/LocalePicker.php
@@ -1,7 +1,11 @@
 <?php namespace RainLab\Translate\Components;
 
+use Cache;
 use Redirect;
+use URL;
+use RainLab\Translate\Models\Locale;
 use RainLab\Translate\Models\Locale as LocaleModel;
+use RainLab\Translate\Models\Preferences;
 use RainLab\Translate\Classes\Translator;
 use Cms\Classes\ComponentBase;
 
@@ -42,7 +46,11 @@ class LocalePicker extends ComponentBase
             return;
 
         $this->translator->setLocale($locale);
-        return Redirect::to($this->currentPageUrl());
+
+        if (!Preferences::get('always_prefix_language_code'))
+            return Redirect::to($this->currentPageUrl());
+
+        return Redirect::to($this->translator->getCurrentPathInLocale($locale));
     }
 
 }

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -5,7 +5,8 @@ return [
         'name' => 'Translate',
         'description' => 'Enables multi-lingual websites.',
         'manage_locales' => 'Manage locales',
-        'manage_messages' => 'Manage messages'
+        'manage_messages' => 'Manage messages',
+        'manage_preferences' => 'Manage preferences',
     ],
     'locale_picker' => [
         'component_name' => 'Locale Picker',
@@ -41,5 +42,13 @@ return [
         'scan_messages_hint' => 'Clicking <strong>Scan for messages</strong> will check the active theme files for any new messages to translate.',
         'hint_translate' => 'Here you can translate messages used on the front-end, the fields will save automatically.',
         'hide_translated' => 'Hide translated',
+    ],
+    'preferences' => [
+        'title' => 'Preferences',
+        'description' => 'Configure the behaviour of the translator.',
+        'always_prefix_language_code' => [
+            'label' => 'Always prefix URL with language code.',
+            'comment' => 'Issue 302 redirects if a URL without language code is accessed. Redirect to language stored in session with fallback to the default language set by the system.',
+        ],
     ],
 ];

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -50,5 +50,9 @@ return [
             'label' => 'Always prefix URL with language code.',
             'comment' => 'Issue 302 redirects if a URL without language code is accessed. Redirect to language stored in session with fallback to the default language set by the system.',
         ],
+        'default_frontend_language' => [
+            'label' => 'Default frontend language:',
+            'comment' => 'The default language to be shown to first time visitor.',
+        ],
     ],
 ];

--- a/models/Preferences.php
+++ b/models/Preferences.php
@@ -23,4 +23,13 @@ class Preferences extends Model
     {
         $this->always_prefix_language_code = false;
     }
+
+    /**
+     * Options for default frontend language perference. Returns all enabled
+     * locales.
+     */
+    public function getDefaultFrontendLanguageOptions($keyValue = null)
+    {
+        return Locale::listEnabled();
+    }
 }

--- a/models/Preferences.php
+++ b/models/Preferences.php
@@ -1,0 +1,26 @@
+<?php namespace RainLab\Translate\Models;
+
+use Model;
+
+/**
+ * Language Plugin Preferences
+ *
+ * @package rainlab\translate
+ * @author Justin Lau
+ */
+class Preferences extends Model
+{
+    public $implement = ['System.Behaviors.SettingsModel'];
+
+    public $settingsCode = 'rainlab_translate_preferences';
+
+    public $settingsFields = 'fields.yaml';
+
+    /**
+     * Default values to set for this model
+     */
+    public function initSettingsData()
+    {
+        $this->always_prefix_language_code = false;
+    }
+}

--- a/models/preferences/fields.yaml
+++ b/models/preferences/fields.yaml
@@ -8,3 +8,8 @@ fields:
         label: rainlab.translate::lang.preferences.always_prefix_language_code.label
         comment: rainlab.translate::lang.preferences.always_prefix_language_code.comment
         type: checkbox
+
+    default_frontend_language:
+        label: rainlab.translate::lang.preferences.default_frontend_language.label
+        comment: rainlab.translate::lang.preferences.default_frontend_language.comment
+        type: dropdown

--- a/models/preferences/fields.yaml
+++ b/models/preferences/fields.yaml
@@ -1,0 +1,10 @@
+# ===================================
+#  Field Definitions
+# ===================================
+
+fields:
+
+    always_prefix_language_code:
+        label: rainlab.translate::lang.preferences.always_prefix_language_code.label
+        comment: rainlab.translate::lang.preferences.always_prefix_language_code.comment
+        type: checkbox

--- a/routes.php
+++ b/routes.php
@@ -2,6 +2,7 @@
 
 use RainLab\Translate\Models\Locale;
 use RainLab\Translate\Models\Message;
+use RainLab\Translate\Models\Preferences;
 use RainLab\Translate\Classes\Translator;
 
 /*
@@ -15,8 +16,28 @@ App::before(function($request) {
 
     $locale = Request::segment(1);
 
-    if (!Locale::isValid($locale))
-        return;
+    // Redirect CMS routes without language code prefix if the
+    // `always_prefix_language_code` preference is turned on.
+    if (!Locale::isValid($locale)) {
+
+        // do not redirect if the setting isn't turned on,
+        // or if the requested path being a backend route.
+        if (!Preferences::get('always_prefix_language_code') ||
+            ltrim(Config::get('cms.backendUri'), '/') == Request::segment(1)) {
+            return;
+        }
+
+        try {
+            // determine if the requested path matches a route defined in other plugins.
+            Route::getRoutes()->match($request);
+
+            return;
+        }
+        catch (\Symfony\Component\HttpKernel\Exception\NotFoundHttpException $exception) {
+            return Redirect::to($translator->getCurrentPathInLocale($translator->getLocale(true)));
+        }
+
+    }
 
     $translator->setLocale($locale);
 

--- a/routes.php
+++ b/routes.php
@@ -34,7 +34,7 @@ App::before(function($request) {
             return;
         }
         catch (\Symfony\Component\HttpKernel\Exception\NotFoundHttpException $exception) {
-            return Redirect::to($translator->getCurrentPathInLocale($translator->getLocale(true)));
+            return Redirect::to($translator->getCurrentPathInLocale(Preferences::get('default_frontend_language')));
         }
 
     }


### PR DESCRIPTION
This PR adds an option in the backend setting to always prefix routes with language code.

Pretty much described in #11, if it is turned on, when a CMS route (not backend, not routes defined in other plugins such as the `debugbar`) is accessed without the locale prefix, it will check against the browser session for the language to use, or fallback to the default language, and returns a 302 redirect to a URL with the prefix. The locale picker will also issue 302 redirects when the languages is changed.

Language check from request header isn't implemented in this PR, as the language code from the browser may not match the user defined language code.