### PR TITLE
Fixed unicode message not translatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor
+composer.lock
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "require-dev": {
+        "keios/oc-plugin-testsuite": "dev-bugfix"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/justin-lau/oc-plugin-testsuite"
+        }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,5 @@
 {
     "require-dev": {
-        "keios/oc-plugin-testsuite": "dev-bugfix"
-    },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/justin-lau/oc-plugin-testsuite"
-        }
-    ]
+        "keios/oc-plugin-testsuite": "dev-master"
+    }
 }

--- a/models/Message.php
+++ b/models/Message.php
@@ -212,6 +212,25 @@ class Message extends Model
      */
     protected static function makeMessageCode($messageId)
     {
+        $separator = '.';
+
+        // Convert all dashes/underscores into separator
+        $flip = $separator == '-' ? '_' : '-';
+        $messageId = preg_replace('!['.preg_quote($flip).']+!u', $separator, $messageId);
+        // Remove all characters that are not the separator, letters, numbers, or whitespace.
+        $messageId = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($messageId));
+        // Replace all separator characters and whitespace by a single separator
+        $messageId = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $messageId);
+
+        return Str::limit(trim($messageId, $separator), 250);
+    }
+
+    /**
+     * @deprecated
+     * @TODO Remove this function in the next major version.
+     */
+    protected static function makeDeprecatedMessageCode($messageId)
+    {
         return Str::limit(strtolower(Str::slug($messageId, '.')), 250);
     }
 

--- a/models/Message.php
+++ b/models/Message.php
@@ -102,11 +102,24 @@ class Message extends Model
         ]);
 
         /*
+         * Copy deprecated message data over if exists.
+         *
+         * TODO: Remove this sinppet in the next major version.
+         */
+        if (!$item->exists) {
+            $deprecatedItem = static::whereCode(self::makeDeprecatedMessageCode($messageId))->first();
+
+            if ($deprecatedItem) {
+                $item->message_data = $deprecatedItem->message_data;
+            }
+        }
+
+        /*
          * Create a default entry
          */
         if (!$item->exists) {
             $data = [static::DEFAULT_LOCALE => $messageId];
-            $item->message_data = $data;
+            $item->message_data = $item->message_data ?: $data;
             $item->save();
         }
 
@@ -137,11 +150,24 @@ class Message extends Model
                 'code' => $messageCode
             ]);
 
+            /*
+             * Copy deprecated message data over if exists.
+             *
+             * TODO: Remove this sinppet in the next major version.
+             */
+            if (!$item->exists) {
+                $deprecatedItem = static::whereCode(self::makeDeprecatedMessageCode($message))->first();
+
+                if ($deprecatedItem) {
+                    $item->message_data = $deprecatedItem->message_data;
+                }
+            }
+
             // Do not import non-default messages that do not exist
             if (!$item->exists && $locale != static::DEFAULT_LOCALE)
                 continue;
 
-            $messageData = $item->exists ? $item->message_data : [];
+            $messageData = $item->exists || $item->message_data ? $item->message_data : [];
             $messageData[$locale] = $message;
 
             $item->message_data = $messageData;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/keios/oc-plugin-testsuite/bootstrap/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false">
+    <testsuites>
+        <testsuite name="Translate Plugin Unit Test Suite">
+            <directory>tests/unit</directory>
+        </testsuite>
+        <testsuite name="Translate Plugin Functional Test Suite">
+            <directory>tests/functional</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/tests/functional/models/MessageTest.php
+++ b/tests/functional/models/MessageTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace RainLab\Translate\Tests\Functional;
+
+use RainLab\Translate\Models\Locale;
+use RainLab\Translate\Models\Message;
+
+class MessageTest extends \OctoberPluginTestCase
+{
+    protected $refreshPlugins = ['RainLab.Translate'];
+
+    public function testImportMessages()
+    {
+        Message::importMessages(['Hello World!', 'Hello Piñata!']);
+        $this->assertNotNull(Message::whereCode('hello.world')->first());
+        $this->assertNotNull(Message::whereCode('hello.pinata')->first());
+    }
+}

--- a/tests/functional/models/MessageTest.php
+++ b/tests/functional/models/MessageTest.php
@@ -2,6 +2,7 @@
 
 namespace RainLab\Translate\Tests\Functional;
 
+use \Model;
 use RainLab\Translate\Models\Locale;
 use RainLab\Translate\Models\Message;
 
@@ -9,10 +10,57 @@ class MessageTest extends \OctoberPluginTestCase
 {
     protected $refreshPlugins = ['RainLab.Translate'];
 
+    public function seedDeprecatedData()
+    {
+        Model::unguard();
+
+        Message::create([
+            'code' => 'hello.pinata', // deprecated message code
+            'message_data' => [
+                'en-US' => 'Hello Piñata!',
+                'zh-HK' => '皮納塔你好！'
+            ]
+        ]);
+
+        Model::reguard();
+    }
+
     public function testImportMessages()
     {
         Message::importMessages(['Hello World!', 'Hello Piñata!']);
+
         $this->assertNotNull(Message::whereCode('hello.world')->first());
         $this->assertNotNull(Message::whereCode('hello.piñata')->first());
+
+        Message::truncate();
+    }
+
+    public function testGetCopiesFromDeprecated() {
+        $this->seedDeprecatedData();
+
+        Message::setContext('en-US');
+        Message::get('Hello Piñata!');
+
+        $newMessage = Message::whereCode('hello.piñata')->first();
+        $deprecatedMessage = Message::whereCode('hello.pinata')->first();
+
+        $this->assertNotNull($newMessage);
+        $this->assertEquals($newMessage->messageData, $deprecatedMessage->messageData);
+
+        Message::truncate();
+    }
+
+    public function testImportMessagesCopiesFromDeprecated() {
+        $this->seedDeprecatedData();
+
+        Message::importMessages(['Hello World!', 'Hello Piñata!']);
+
+        $newMessage = Message::whereCode('hello.piñata')->first();
+        $deprecatedMessage = Message::whereCode('hello.pinata')->first();
+
+        $this->assertNotNull($newMessage);
+        $this->assertEquals($newMessage->messageData, $deprecatedMessage->messageData);
+
+        Message::truncate();
     }
 }

--- a/tests/functional/models/MessageTest.php
+++ b/tests/functional/models/MessageTest.php
@@ -13,6 +13,6 @@ class MessageTest extends \OctoberPluginTestCase
     {
         Message::importMessages(['Hello World!', 'Hello Piñata!']);
         $this->assertNotNull(Message::whereCode('hello.world')->first());
-        $this->assertNotNull(Message::whereCode('hello.pinata')->first());
+        $this->assertNotNull(Message::whereCode('hello.piñata')->first());
     }
 }

--- a/tests/unit/models/MessageTest.php
+++ b/tests/unit/models/MessageTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace RainLab\Translate\Tests\Unit;
+
+use RainLab\Translate\Models\Message;
+
+class MessageTest extends \OctoberPluginTestCase
+{
+    protected $requiresOctoberMigration = true;
+
+    public function testMakeMessageCode()
+    {
+        $this->assertEquals('hello.world', Message::makeMessageCode('hello world'));
+        $this->assertEquals('hello.world', Message::makeMessageCode(' hello world '));
+        $this->assertEquals('hello.world', Message::makeMessageCode('hello-world'));
+        $this->assertEquals('hello.world', Message::makeMessageCode('hello--world'));
+
+        // casing
+        $this->assertEquals('hello.world', Message::makeMessageCode('Hello World'));
+        $this->assertEquals('hello.world', Message::makeMessageCode('Hello World!'));
+
+        // underscores
+        $this->assertEquals('helloworld', Message::makeMessageCode('hello_world'));
+        $this->assertEquals('helloworld', Message::makeMessageCode('hello__world'));
+
+        // length limit
+        $veryLongString = str_repeat("10 charstr", 30);
+        $this->assertTrue(strlen($veryLongString) > 250);
+        $this->assertEquals(253, strlen(Message::makeMessageCode($veryLongString)));
+        $this->assertStringEndsWith('...', Message::makeMessageCode($veryLongString));
+
+        // unicode characters
+        // brrowered some test cases from Stringy, the library Laravel's
+        // `slug()` function depends on
+        // https://github.com/danielstjules/Stringy/blob/master/tests/CommonTest.php
+        $this->assertEquals('foo.bar', Message::makeMessageCode('fòô bàř'));
+        $this->assertEquals('test', Message::makeMessageCode(' ŤÉŚŢ '));
+        $this->assertEquals('f.z.3', Message::makeMessageCode('φ = ź = 3'));
+        $this->assertEquals('perevirka', Message::makeMessageCode('перевірка'));
+        $this->assertEquals('lysaya.gora', Message::makeMessageCode('лысая гора'));
+        $this->assertEquals('shchuka', Message::makeMessageCode('щука'));
+        $this->assertEquals('foo', Message::makeMessageCode('foo 漢字')); // Chinese
+        $this->assertEquals('xin.chao.the.gioi', Message::makeMessageCode('xin chào thế giới'));
+        $this->assertEquals('xin.chao.the.gioi', Message::makeMessageCode('XIN CHÀO THẾ GIỚI'));
+        $this->assertEquals('dam.phat.chet.luon', Message::makeMessageCode('đấm phát chết luôn'));
+        $this->assertEquals('foo', Message::makeMessageCode('foo ')); // no-break space (U+00A0)
+        $this->assertEquals('foo', Message::makeMessageCode('foo           ')); // spaces U+2000 to U+200A
+        $this->assertEquals('foo', Message::makeMessageCode('foo ')); // narrow no-break space (U+202F)
+        $this->assertEquals('foo', Message::makeMessageCode('foo ')); // medium mathematical space (U+205F)
+        $this->assertEquals('foo', Message::makeMessageCode('foo　')); // ideographic space (U+3000)
+    }
+
+}

--- a/tests/unit/models/MessageTest.php
+++ b/tests/unit/models/MessageTest.php
@@ -33,16 +33,16 @@ class MessageTest extends \OctoberPluginTestCase
         // brrowered some test cases from Stringy, the library Laravel's
         // `slug()` function depends on
         // https://github.com/danielstjules/Stringy/blob/master/tests/CommonTest.php
-        $this->assertEquals('foo.bar', Message::makeMessageCode('fòô bàř'));
-        $this->assertEquals('test', Message::makeMessageCode(' ŤÉŚŢ '));
-        $this->assertEquals('f.z.3', Message::makeMessageCode('φ = ź = 3'));
-        $this->assertEquals('perevirka', Message::makeMessageCode('перевірка'));
-        $this->assertEquals('lysaya.gora', Message::makeMessageCode('лысая гора'));
-        $this->assertEquals('shchuka', Message::makeMessageCode('щука'));
-        $this->assertEquals('foo', Message::makeMessageCode('foo 漢字')); // Chinese
-        $this->assertEquals('xin.chao.the.gioi', Message::makeMessageCode('xin chào thế giới'));
-        $this->assertEquals('xin.chao.the.gioi', Message::makeMessageCode('XIN CHÀO THẾ GIỚI'));
-        $this->assertEquals('dam.phat.chet.luon', Message::makeMessageCode('đấm phát chết luôn'));
+        $this->assertEquals('fòô.bàř', Message::makeMessageCode('fòô bàř'));
+        $this->assertEquals('ťéśţ', Message::makeMessageCode(' ŤÉŚŢ '));
+        $this->assertEquals('φ.ź.3', Message::makeMessageCode('φ = ź = 3'));
+        $this->assertEquals('перевірка', Message::makeMessageCode('перевірка'));
+        $this->assertEquals('лысая.гора', Message::makeMessageCode('лысая гора'));
+        $this->assertEquals('щука', Message::makeMessageCode('щука'));
+        $this->assertEquals('foo.漢字', Message::makeMessageCode('foo 漢字')); // Chinese
+        $this->assertEquals('xin.chào.thế.giới', Message::makeMessageCode('xin chào thế giới'));
+        $this->assertEquals('xin.chào.thế.giới', Message::makeMessageCode('XIN CHÀO THẾ GIỚI'));
+        $this->assertEquals('đấm.phát.chết.luôn', Message::makeMessageCode('đấm phát chết luôn'));
         $this->assertEquals('foo', Message::makeMessageCode('foo ')); // no-break space (U+00A0)
         $this->assertEquals('foo', Message::makeMessageCode('foo           ')); // spaces U+2000 to U+200A
         $this->assertEquals('foo', Message::makeMessageCode('foo ')); // narrow no-break space (U+202F)


### PR DESCRIPTION
This PR fixes #82. I have created it based on an assumption that the message codes are merely used as a key of the hash table of messages. If I have overlooked anything, hashing may not be the way to solve the unicode message issue. Anyway, I need unicode messages to be translatable in my current project and I have tested and confirmed it working great with unicode messages as well as the English based ones.

The message code is replaced by a hash value using [MurmurHash 3](https://github.com/lastguest/murmurhash-php), the [fastest non-cryptographic hashing algorithm](https://github.com/Cyan4973/xxHash#benchmarks) I can find without the need of an extension, yet has a fairly well collision avoidance. (Extended reading: [Hash functions: An empirical comparison](http://www.strchr.com/hash_functions))

This PR changes the way the message code is generated, therefore **it breaks the ability to lookup previously stored messages**.