### PR TITLE
fixed translation not showing up on load

### DIFF
--- a/formwidgets/mltextarea/partials/_mltextarea.htm
+++ b/formwidgets/mltextarea/partials/_mltextarea.htm
@@ -12,11 +12,11 @@
         <textarea
             name="<?= $field->getName() ?>"
             id="<?= $field->getId('placeholderField') ?>"
-            value="<?= e($field->value) ?>"
+            value=""
             placeholder="<?= e(trans($field->placeholder)) ?>"
             class="form-control field-textarea size-<?= $field->size ?>"
             autocomplete="off"
-            <?= $field->getAttributes() ?>></textarea>
+            <?= $field->getAttributes() ?>><?= e($field->value) ?></textarea>
 
         <button
             class="btn btn-default"


### PR DESCRIPTION
Textarea value is handled at inner HTML. Translated value should be moved from attribute "value" to inner HTML.