### PR TITLE
Fixed the flush message display

### DIFF
--- a/controllers/messages/index.htm
+++ b/controllers/messages/index.htm
@@ -5,7 +5,7 @@
     </ul>
 <?php Block::endPut() ?>
 
-<div class="callout-container">
+<div class="padded-container container-flush">
     <?= $this->makeHintPartial('translation_messages_hint', 'hint') ?>
 </div>
 
@@ -24,11 +24,10 @@
 <!-- Set the Header values in the Grid -->
 <script>
 
-$(document).render(function(){
+$(document).render(function() {
     $.translateMessages.setTableElement('#<?= $table->getId() ?>')
     $.translateMessages.setTitleContents('#<?= $this->getId('fromTitle') ?>', '#<?= $this->getId('toTitle') ?>')
     $.translateMessages.setToolbarContents('#<?= $this->getId('tableToolbar') ?>')
 })
 
 </script>
-


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/2959112/15740532/84ec0474-28b5-11e6-945a-b4a5536f11c2.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/2959112/15740545/8cd43a1c-28b5-11e6-9434-5c807628b65a.jpg)

The layout code is same, but the margin top of flush message is missing. I don't understand the reason.