### PR TITLE
Set value to an empty string if empty

### DIFF
--- a/traits/mlcontrol/partials/_locale_values.htm
+++ b/traits/mlcontrol/partials/_locale_values.htm
@@ -2,6 +2,8 @@
 <?php foreach ($locales as $code => $name): ?>
     <?php
         $value = ($value = $this->getLocaleValue($code)) && $this->isLocaleFieldJsonable() ? json_encode($value) : $value;
+        if (empty($value))
+            $value = "";
     ?>
     <input
         type="hidden"


### PR DESCRIPTION
If this is not done, laravels escaping helper function `e` will through an error

> "htmlentities() expects parameter 1 to be string, array given" on line 469 of /vendor/laravel/framework/src/Illuminate/Support/helpers.php