### PR TITLE
storeTranslatableIndexData returning within a loop

### DIFF
--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -128,7 +128,6 @@ class TranslatableModel extends TranslatableBehavior
         }
 
         $data = $this->translatableAttributes[$locale];
-
         foreach ($optionedAttributes as $attribute => $options) {
             if (!array_get($options, 'index', false)) {
                 continue;
@@ -148,13 +147,12 @@ class TranslatableModel extends TranslatableBehavior
                 if ($recordExists) {
                     $obj->delete();
                 }
-                return;
+                continue;
             }
 
             if ($recordExists) {
                 $obj->update(['value' => $value]);
-            }
-            else {
+            } else {
                 Db::table('rainlab_translate_indexes')->insert([
                     'locale' => $locale,
                     'model_id' => $this->model->getKey(),
@@ -163,7 +161,6 @@ class TranslatableModel extends TranslatableBehavior
                     'value' => $value
                 ]);
             }
-
         }
     }
 

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -128,6 +128,7 @@ class TranslatableModel extends TranslatableBehavior
         }
 
         $data = $this->translatableAttributes[$locale];
+
         foreach ($optionedAttributes as $attribute => $options) {
             if (!array_get($options, 'index', false)) {
                 continue;
@@ -152,7 +153,8 @@ class TranslatableModel extends TranslatableBehavior
 
             if ($recordExists) {
                 $obj->update(['value' => $value]);
-            } else {
+            }
+            else {
                 Db::table('rainlab_translate_indexes')->insert([
                     'locale' => $locale,
                     'model_id' => $this->model->getKey(),


### PR DESCRIPTION
When updating a model, the storeTranslatableIndexData is called. Inside the foreach loop, if any of the attributes are empty strings, on line 151, it returns and drops out. If the next attribute is not empty, and needs to be updated, it fails. Changing this to a continue resolves this. 

Don't believe I'm missing anything but if there's a better solution or a reason for the return, happy to change!
Thanks, 
James