### PR TITLE
DefaultLocale is now checking for a Session variable before using default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 .DS_Store
+.idea

--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -1,5 +1,6 @@
 <?php namespace RainLab\Translate\Traits;
 
+use Illuminate\Support\Facades\Session;
 use Str;
 use RainLab\Translate\Models\Locale;
 use Backend\Classes\FormWidgetBase;
@@ -35,7 +36,7 @@ trait MLControl
      */
     public function initLocale()
     {
-        $this->defaultLocale = Locale::getDefault();
+        $this->defaultLocale = Session::get('rainlab.translate.inputLocale') ? Locale::findByCode(Session::get('rainlab.translate.inputLocale')) : Locale::getDefault();
         $this->parentViewPath = $this->guessViewPathFrom(__TRAIT__, '/partials');
         $this->isAvailable = Locale::isAvailable();
     }


### PR DESCRIPTION
The purpose for this commit is to facilitate changing the input language on the back end by checking a Session variable for a locale before creating a multilingual control instead of always using the default locale.