### PR TITLE
Add missing web middleware

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -34,7 +34,7 @@ App::before(function($request) {
         Route::any('{slug}', 'Cms\Classes\CmsController@run')->where('slug', '(.*)?');
     });
 
-    Route::any($locale, 'Cms\Classes\CmsController@run');
+    Route::any($locale, 'Cms\Classes\CmsController@run')->middleware('web');
 
     /*
      * Ensure Url::action() retains the localized URL


### PR DESCRIPTION
When upgrading to Laravel 5.5 I got an error when visiting the homepage in a foreign locale: "Session store not set on request." Adding the "web" middleware to one remaining route fixed it.

I believe this was just an oversight in this commit: https://github.com/rainlab/translate-plugin/commit/aa6e523dbe47c60e6ee318e3a7e1a32d7ca52db8