### PR TITLE
Support maxlength attribute

### DIFF
--- a/formwidgets/mltext/partials/_mltext.htm
+++ b/formwidgets/mltext/partials/_mltext.htm
@@ -17,7 +17,7 @@
             placeholder="<?= e(trans($field->placeholder)) ?>"
             class="form-control"
             autocomplete="off"
-            maxlength="255"
+            <?= $field->hasAttribute('maxlength') ? '' : 'maxlength="255"' ?>
             <?= $field->getAttributes() ?>
         />
 


### PR DESCRIPTION
I moved this change to its own branch, please close #199 

This is a small change that allows to define a maxlength attribute for a multilanguage text field