### PR TITLE
Ensure that translatableData has been loaded in hasTranslation()

### DIFF
--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -186,7 +186,26 @@ abstract class TranslatableBehavior extends ExtensionBase
      */
     public function hasTranslation($key, $locale)
     {
-        return !!$this->getAttributeFromData($this->translatableAttributes[$locale], $key);
+        /*
+         * If the default locale is passed, the attributes are retreived from the model,
+         * otherwise fetch the attributes from the $translatableAttributes property
+         */
+        if ($locale == $this->translatableDefault) {
+            $translatableAttributes = $this->model->attributes;
+        }
+        else {          
+            /*
+             * Ensure that the translatableData has been loaded
+             * @see https://github.com/rainlab/translate-plugin/issues/302
+             */
+            if (!isset($this->translatableAttributes[$locale])) {
+                $this->loadTranslatableData($locale);
+            }
+
+            $translatableAttributes = $this->translatableAttributes[$locale];
+        }
+
+        return !!$this->getAttributeFromData($translatableAttributes, $key);
     }
 
     /**


### PR DESCRIPTION
When using the method hasTranslation() we need to make sure that the translatableData has been loaded, just like in a few other methods, otherwise an undefined index will halt execution.

@see https://github.com/rainlab/translate-plugin/issues/302