### PR TITLE
Update Dutch (NL) language file

### DIFF
--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -1,11 +1,10 @@
-<?php
-
-return [
+<?php return [
     'plugin' => [
         'name' => 'Vertaal',
         'description' => 'Stelt meerdere talen in voor een website.',
-        'manage_locales' => 'Manage locales',
-        'manage_messages' => 'Manage messages'
+        'tab' => 'Vertalingen',
+        'manage_locales' => 'Beheer talen',
+        'manage_messages' => 'Beheer berichten'
     ],
     'locale_picker' => [
         'component_name' => 'Taalkeuze menu',
@@ -18,6 +17,7 @@ return [
         'select_label' => 'Selecteer taal',
         'default_suffix' => 'standaard',
         'unset_default' => '":locale" is al de standaard taal en kan niet worden uitgeschakeld',
+        'delete_default' => '":locale" is de standaard tal en kan niet worden verwijderd.',
         'disabled_default' => '":locale" is uitgeschakeld en kan niet worden gezet als standaard taal.',
         'name' => 'Naam',
         'code' => 'Code',
@@ -27,18 +27,26 @@ return [
         'is_enabled_help' => 'Uitgeschakelde talen zijn niet beschikbaar op de website.',
         'not_available_help' => 'Er zijn geen andere talen beschikbaar.',
         'hint_locales' => 'Voeg hier nieuwe talen toe voor het vertalen van de website inhoud. De standaard taal weergeeft de inhoud voordat het is vertaald. ',
+        'reorder_title' => 'Talen rangschikken',
+        'sort_order' => 'Volgorde',
     ],
     'messages' => [
         'title' => 'Vertaal berichten',
-		'description' => 'Wijzig berichten',
+        'description' => 'Wijzig berichten',
         'clear_cache_link' => 'Leeg cache',
         'clear_cache_loading' => 'Applicatie cache legen...',
         'clear_cache_success' => 'De applicatie cache is succesvol geleegd.',
         'clear_cache_hint' => 'Het is verstandig om regelmatig op <strong>Leeg cache</strong> te klikken om de veranderingen te zien op de website.',
         'scan_messages_link' => 'Zoek naar nieuwe berichten',
+        'scan_messages_begin_scan' => 'Begin scan',
         'scan_messages_loading' => 'Zoeken naar nieuwe berichten...',
         'scan_messages_success' => 'De thema bestanden zijn succesvol gescand!',
-        'scan_messages_hint' => 'Klikken op <strong>Zoeken naar nieuwe berichten</strong> controleert de actieve thema bestanden voor nieuwe berichten om te vertalen. ',
+        'scan_messages_hint' => 'Klikken op <strong>Zoeken naar nieuwe berichten</strong> controleert het huidige thema bestanden voor nieuwe berichten om te vertalen. ',
+        'scan_messages_process' => 'Dit proces zal probreren het huidige thema te scannen voor berichten om te vertalen',
+        'scan_messages_process_limitations' => 'Sommige berichten zullen niet worden herkent en zullen pas verschijnen nadat ze voor de eerste keer zijn gebruikt',
+        'scan_messages_purge_label' => 'Verwijder eerst alle berichten',
+        'scan_messages_purge_help' => 'Als dit is aangevinkt zullen alle berichten worden verwijderd voordat de scan wordt uitgevoerd.',
+        'scan_messages_purge_confirm' => 'Weet je zeker dat je alle berichten wilt verwijderen? Dit kan niet ongedaan gemaakt worden',
         'hint_translate' => 'Hier kan je berichten vertalen die worden gebruikt op de website. De velden worden automatisch opgeslagen.',
         'hide_translated' => 'Verberg vertaalde berichten',
     ],


### PR DESCRIPTION
Updates Dutch ( `/lang/nl/lang.php` ) file. Iterates on #233 and adds the other missing translation keys that have been added since.

Preferably needs a check by another Dutchie. 