### PR TITLE
Adding the possibility to skip session retrieval

### DIFF
--- a/classes/LocaleMiddleware.php
+++ b/classes/LocaleMiddleware.php
@@ -17,7 +17,8 @@ class LocaleMiddleware
         $translator = Translator::instance();
         $translator->isConfigured();
 
-        if (!$translator->loadLocaleFromRequest()) {
+
+        if (!$translator->loadLocaleFromRequest() && !$translator->skipSessionLocaleRetrieval()) {
             $translator->loadLocaleFromSession();
         }
 

--- a/classes/Translator.php
+++ b/classes/Translator.php
@@ -91,7 +91,7 @@ class Translator
     }
 
     /**
-     * Check if this plugin is installed and the database is available, 
+     * Check if this plugin is installed and the database is available,
      * stores the result in the session for efficiency.
      * @return boolean
      */
@@ -208,4 +208,17 @@ class Translator
     {
         Session::put(self::SESSION_LOCALE, $locale);
     }
+
+    /**
+     * Should we load the locale from the session?
+     * See https://github.com/rainlab/translate-plugin/issues/315
+     *
+     * @return boolean
+     */
+    public function skipSessionLocaleRetrieval()
+    {
+        return config('cms.translate.skipSession', false);
+
+    }
+
 }

--- a/classes/Translator.php
+++ b/classes/Translator.php
@@ -2,6 +2,7 @@
 
 use App;
 use Schema;
+use Config;
 use Session;
 use Request;
 use RainLab\Translate\Models\Locale;
@@ -217,8 +218,7 @@ class Translator
      */
     public function skipSessionLocaleRetrieval()
     {
-        return config('cms.translate.skipSession', false);
-
+        return Config::get('rainlab.translate::skipSession', false);
     }
 
 }

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Skip Session
+    |--------------------------------------------------------------------------
+    |
+    | When using the rainlab.Translate plugin it sometimes is necessary to
+    | skip te retrieval of the locale from the session in order to let
+    | the main-root of the domain stay in the default language. (instead of
+    | showing the last visited locale = locale stored in the session)
+    | default = false
+    */
+    'skipSession' => false
+];


### PR DESCRIPTION
As discussed in #315 this is a solution to add a setting which skips the retrieval of the locale from the session. 
By the default the behaviour of the plugin is not changed; when visiting the `domain.tld/` route it wil display the __last loaded__ locale. 
Setting `skipSession = true` will disable this and keep the locale on the default locale. Result is a SEO friendly domain-structure; where every locale has one, and only one unique url-path.  

To activate this add an entry in `/config/cms.php`
```php
...
'translate' => [
    'skipSession' => true
]
...
```

