### PR TITLE
PrefixDefaultLocale setting and Alt hreflang element

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -103,7 +103,8 @@ class Plugin extends PluginBase
     public function registerComponents()
     {
         return [
-           'RainLab\Translate\Components\LocalePicker' => 'localePicker'
+           'RainLab\Translate\Components\LocalePicker' => 'localePicker',
+           'RainLab\Translate\Components\AlternateHrefLangElements' => 'alternateHrefLangElements'
         ];
     }
 

--- a/classes/Translator.php
+++ b/classes/Translator.php
@@ -91,7 +91,7 @@ class Translator
     }
 
     /**
-     * Check if this plugin is installed and the database is available, 
+     * Check if this plugin is installed and the database is available,
      * stores the result in the session for efficiency.
      * @return boolean
      */
@@ -151,9 +151,10 @@ class Translator
      *
      * @param string $path Path to rewrite
      * @param string $locale optional language code, default to the system default language
+     * @param boolean $removeDefaultLocale dont prefix the path with the default locale
      * @return string
      */
-    public function getPathInLocale($path, $locale = null)
+    public function getPathInLocale($path, $locale = null, $removeDefaultLocale = false)
     {
         $segments = explode('/', $path);
 
@@ -171,6 +172,12 @@ class Translator
         else {
             array_unshift($segments, $locale);
         }
+
+        if ($removeDefaultLocale
+            && isset($segments[0]) && $segments[0] == $this->defaultLocale
+        ) {
+            array_shift($segments);
+        };
 
         return implode('/', $segments);
     }

--- a/classes/Translator.php
+++ b/classes/Translator.php
@@ -184,7 +184,7 @@ class Translator
             && isset($segments[0])
             && $segments[0] == $this->defaultLocale
         ) {
-            // remove the first element (whichis the default locale)
+            // remove the first element (which is the default locale)
             array_shift($segments);
         };
 

--- a/components/AlternateHrefLangElements.php
+++ b/components/AlternateHrefLangElements.php
@@ -36,7 +36,7 @@ class AlternateHrefLangElements extends ComponentBase
     {
         $translator = Translator::instance();
         $page = $this->getPage();
-        
+
         /*
          * Static Page
          */
@@ -55,7 +55,7 @@ class AlternateHrefLangElements extends ComponentBase
             $localeUrl = $router->urlFromPattern($page->url, $params);
         }
 
-        return $translator->getPathInLocale($localeUrl, $locale, true);
+        return $translator->getPathInLocale($localeUrl, $locale);
     }
 
 }

--- a/components/AlternateHrefLangElements.php
+++ b/components/AlternateHrefLangElements.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rainlab\Translate\Components;
+
+use Cms\Classes\ComponentBase;
+use RainLab\Translate\Classes\Translator;
+use RainLab\Translate\Models\Locale as LocaleModel;
+use October\Rain\Router\Router as RainRouter;
+
+class AlternateHrefLangElements extends ComponentBase
+{
+
+
+    public function componentDetails()
+    {
+        return [
+            'name' => 'Alternate HREF Lang elements',
+            'description' => 'Injects the language alternatives as hreflang elements'
+        ];
+    }
+
+    public function locales()
+    {
+        // Available locales
+        $locales = collect(LocaleModel::listEnabled());
+
+        // Transform it to contain the new urls
+        $locales->transform(function ($item, $key) {
+            return $this->retrieveLocalizedUrl($key);
+        });
+
+        return $locales->toArray();
+    }
+
+    private function retrieveLocalizedUrl($locale)
+    {
+        $translator = Translator::instance();
+        $page = $this->getPage();
+        
+        /*
+         * Static Page
+         */
+        if (isset($page->apiBag['staticPage'])) {
+            $staticPage = $page->apiBag['staticPage'];
+            $staticPage->rewriteTranslatablePageUrl($locale);
+            $localeUrl = array_get($staticPage->attributes, 'viewBag.url');
+        }
+        /*
+         * CMS Page
+         */
+        else {
+            $page->rewriteTranslatablePageUrl($locale);
+            $router = new RainRouter;
+            $params = $this->getRouter()->getParameters();
+            $localeUrl = $router->urlFromPattern($page->url, $params);
+        }
+
+        return $translator->getPathInLocale($localeUrl, $locale, true);
+    }
+
+}

--- a/components/AlternateHrefLangElements.php
+++ b/components/AlternateHrefLangElements.php
@@ -14,8 +14,8 @@ class AlternateHrefLangElements extends ComponentBase
     public function componentDetails()
     {
         return [
-            'name' => 'Alternate HREF Lang elements',
-            'description' => 'Injects the language alternatives as hreflang elements'
+            'name'        => 'rainlab.translate::lang.alternate_hreflang.component_name',
+            'description' => 'rainlab.translate::lang.alternate_hreflang.component_description'
         ];
     }
 

--- a/components/LocalePicker.php
+++ b/components/LocalePicker.php
@@ -2,6 +2,7 @@
 
 use Request;
 use Redirect;
+use Config;
 use RainLab\Translate\Models\Locale as LocaleModel;
 use RainLab\Translate\Classes\Translator;
 use October\Rain\Router\Router as RainRouter;
@@ -92,10 +93,21 @@ class LocalePicker extends ComponentBase
             return;
         }
 
-        $locale = $this->translator->getLocale(true)
+        $prefixDefaultLocale = Config::get('rainlab.translate::prefixDefaultLocale');
+        $locale = $this->translator->getLocale(false)
             ?: $this->translator->getDefaultLocale();
 
-        return Redirect::to($this->translator->getCurrentPathInLocale($locale));
+        if ($prefixDefaultLocale) {
+
+            return Redirect::to($this->translator->getCurrentPathInLocale($locale));
+
+        } elseif ( $locale == $this->translator->getDefaultLocale()) {
+            return;
+        } else {
+            $this->translator->setLocale($this->translator->getDefaultLocale());
+            return;
+        }
+
     }
 
     /**

--- a/components/alternatehreflangelements/default.htm
+++ b/components/alternatehreflangelements/default.htm
@@ -1,3 +1,3 @@
-{% for l, u in __SELF__.locales %}
-    <link rel="alternate" hreflang="{{ l }}" href="{{ url(u) }}" />
+{% for locale, alternateUrl in __SELF__.locales %}
+    <link rel="alternate" hreflang="{{ locale }}" href="{{ url(alternateUrl) }}" />
 {% endfor %}

--- a/components/alternatehreflangelements/default.htm
+++ b/components/alternatehreflangelements/default.htm
@@ -1,3 +1,3 @@
 {% for loc, url in __SELF__.locales %}
-    <link rel="alternate" hreflang="{{ loc }}" href="{{ url }}" />
+    <link rel="alternate" hreflang="{{ loc }}" href="/{{ url }}" />
 {% endfor %}

--- a/components/alternatehreflangelements/default.htm
+++ b/components/alternatehreflangelements/default.htm
@@ -1,3 +1,3 @@
-{% for loc, url in __SELF__.locales %}
-    <link rel="alternate" hreflang="{{ loc }}" href="/{{ url }}" />
+{% for l, u in __SELF__.locales %}
+    <link rel="alternate" hreflang="{{ l }}" href="{{ url(u) }}" />
 {% endfor %}

--- a/components/alternatehreflangelements/default.htm
+++ b/components/alternatehreflangelements/default.htm
@@ -1,0 +1,3 @@
+{% for loc, url in __SELF__.locales %}
+    <link rel="alternate" hreflang="{{ loc }}" href="{{ url }}" />
+{% endfor %}

--- a/config/config.php
+++ b/config/config.php
@@ -11,6 +11,6 @@ return [
     | ( For now only used in the alternate-hreflang cmponent )
     |
     */
-    'prefixDefaultLocale' => false
+    'prefixDefaultLocale' => true
 
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | prefix the default Locale
+    |--------------------------------------------------------------------------
+    |
+    | Should the default locale be prefixed by the plugin?
+    |
+    | ( For now only used in the alternate-hreflang cmponent )
+    |
+    */
+    'prefixDefaultLocale' => false
+
+];

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -10,6 +10,10 @@
         'component_name' => 'Locale Picker',
         'component_description' => 'Shows a dropdown to select a front-end language.',
     ],
+    'alternate_hreflang' => [
+        'component_name' => 'Alternate hrefLang elements',
+        'component_description' => 'Injects the language alternatives for page as hreflang elements'
+    ],
     'locale' => [
         'title' => 'Manage languages',
         'update_title' => 'Update language',

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -10,6 +10,10 @@
         'component_name' => 'Taalkeuze menu',
         'component_description' => 'Geeft een taal keuzemenu weer om de taal te wijzigen voor de website.',
     ],
+    'alternate_hreflang' => [
+        'component_name' => 'Alternatieve hrefLang elementen',
+        'component_description' => 'Toont hreflang elementen voor de alt. talen'
+    ],
     'locale' => [
         'title' => 'Beheer talen',
         'update_title' => 'Wijzig taal',


### PR DESCRIPTION
This PR adds two things to the translate plugin:
1 - A component which renders alt hreflang elements 
2 - adds a setting to ask if we need to prefix the default locale

## Alternate hreflang elements
According to [Google's locale recommendations](https://support.google.com/webmasters/answer/189077) we need to inject alternative languages in the head of a website as following:
```html
<link rel="alternate" hreflang="en" href="/en" />
<link rel="alternate" hreflang="nl" href="/nl" />
```
This needs to be done for _every_ language including the current language.

When creating this component, the fact I didn't want to have the default locale prefixed, issue #315 regarding the behaviour when redirecting to the default locale and PR #317 let me to alter the behaviour of the forceurl redirect-method, the second part of this PR

## prefixDefaultLocale
You can override the setting locally in [your own config file.](http://octobercms.com/docs/plugin/settings#file-configuration)
What it does: 
When having `forceURL schema = true` and `prefixDefaultLocale=false` the website wont redirect the default locale to `/default_locale/...` Instead it just remains on the main-root.
To make sure the main root does not display the session-stored locale; the session locale gets reset in the same method :)
If you leave `prefixDefaultLocale=true` nothing should change :)


