### PR TITLE
Cast attributes are saved to db and to 'rainlab_translate_attributes'…

### DIFF
--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -399,7 +399,18 @@ abstract class TranslatableBehavior extends ExtensionBase
     {
         $keyArray = HtmlHelper::nameToArray($attribute);
 
-        return array_get($data, implode('.', $keyArray));
+        $path = implode('.', $keyArray);
+        $val =  array_get($data, $path);
+
+        // For json attributes
+        if (is_null($val) && count($keyArray) > 1 && isset($data[$keyArray[0]]) && is_string($data[$keyArray[0]])) {
+            $data[$keyArray[0]] =  json_decode($data[$keyArray[0]], true);
+            if (!is_null($data[$keyArray[0]])) {
+                $val = array_get($data, $path);
+            }
+        }
+
+        return $val;
     }
 
     /**


### PR DESCRIPTION
… but have empty value for default language in editor

Model.php:

public $translatable = ['title', 'fields[test11]', 'fields[test12]', 'fields[test21]'];
protected $casts = [
        'fields' => 'array'
    ];
fields.yml:

        'fields[test11]':
            label: Test11
            type: text
            tab: 'Content'
        'fields[test12]':
            label: Test12
            type: text
            tab: 'Content'
After saving data I have proper values in DB. I open this form for editing and switch to not default language, then back to default - and field becomes empty.

I'm using latest october version. For other field types like Markdown it works same way.