### PR TITLE
 Update middleware to use prefixDefaultLocale 

### DIFF
--- a/classes/LocaleMiddleware.php
+++ b/classes/LocaleMiddleware.php
@@ -2,6 +2,7 @@
 
 use RainLab\Translate\Classes\Translator;
 use Closure;
+use Config;
 
 class LocaleMiddleware
 {
@@ -12,13 +13,13 @@ class LocaleMiddleware
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next)                                                                                                                                  
-    {                                                                                                                                                                                
+    public function handle($request, Closure $next)
+    {
         $translator = Translator::instance();
         $translator->isConfigured();
 
-        if( ! $translator->loadLocaleFromRequest()) {
-            if(Config::get('translate.prefixDefaultLocale')) {
+        if (!$translator->loadLocaleFromRequest()) {
+            if (Config::get('translate.prefixDefaultLocale')) {
                 $translator->loadLocaleFromSession();
             } else {
                 $translator->setLocale($translator->getDefaultLocale());

--- a/classes/LocaleMiddleware.php
+++ b/classes/LocaleMiddleware.php
@@ -24,8 +24,8 @@ class LocaleMiddleware
             } else {
                 $translator->setLocale($translator->getDefaultLocale());
             }
-         }
+        }
 
-         return $next($request);
+        return $next($request);
     }
 }

--- a/classes/LocaleMiddleware.php
+++ b/classes/LocaleMiddleware.php
@@ -12,15 +12,19 @@ class LocaleMiddleware
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next)
-    {
+    public function handle($request, Closure $next)                                                                                                                                  
+    {                                                                                                                                                                                
         $translator = Translator::instance();
         $translator->isConfigured();
 
-        if (!$translator->loadLocaleFromRequest()) {
-            $translator->loadLocaleFromSession();
-        }
+        if( ! $translator->loadLocaleFromRequest()) {
+            if(Config::get('translate.prefixDefaultLocale')) {
+                $translator->loadLocaleFromSession();
+            } else {
+                $translator->setLocale($translator->getDefaultLocale());
+            }
+         }
 
-        return $next($request);
+         return $next($request);
     }
 }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -45,3 +45,4 @@
 1.3.3: Fix to the locale picker session handling in Build 420 onwards.
 1.3.4: Add alternate hreflang elements and adds prefixDefaultLocale setting.
 1.3.5: Fix MLRepeater bug when switching locales.
+1.3.6: Fix Middleware to use the prefixDefaultLocale setting introduced in 134

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -45,4 +45,4 @@
 1.3.3: Fix to the locale picker session handling in Build 420 onwards.
 1.3.4: Add alternate hreflang elements and adds prefixDefaultLocale setting.
 1.3.5: Fix MLRepeater bug when switching locales.
-1.3.6: Fix Middleware to use the prefixDefaultLocale setting introduced in 134
+1.3.6: Fix Middleware to use the prefixDefaultLocale setting introduced in 1.3.4


### PR DESCRIPTION
With regards of [this issue](https://github.com/rainlab/translate-plugin/pull/318#issuecomment-354567683) this PR will add a check for the prefixDefaultLocale setting into the middleware.

As a result the said wrong behaviour will disappear :)

Thanks @msimkunas for speeding up the debugging a lot 👍 

