### PR TITLE
Fix repeater content not updated on switch locale

### DIFF
--- a/formwidgets/MLRepeater.php
+++ b/formwidgets/MLRepeater.php
@@ -124,6 +124,7 @@ class MLRepeater extends Repeater
             }
             else {
                 $widget->setFormValues($value);
+                $this->formField->value[$key] = $value;
             }
         }
 


### PR DESCRIPTION
On the back end when switching locale to a repeater with a rich editor the field contents would not be updated and the default language contents (en) would be shown.