### PR TITLE
preserve query string, when switching locales

### DIFF
--- a/components/LocalePicker.php
+++ b/components/LocalePicker.php
@@ -76,6 +76,10 @@ class LocalePicker extends ComponentBase
 
         $pageUrl = $this->makeLocaleUrlFromPage($locale);
 
+        // preserve the query string, if it exists
+        $query = http_build_query(request()->query());
+        $pageUrl = $query ? $pageUrl . '?' . $query : $pageUrl;
+
         if ($this->property('forceUrl')) {
             return Redirect::to($this->translator->getPathInLocale($pageUrl, $locale));
         }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -47,3 +47,4 @@
 1.3.5: Fix MLRepeater bug when switching locales.
 1.3.6: Fix Middleware to use the prefixDefaultLocale setting introduced in 1.3.4
 1.3.7: Fix config reference in LocaleMiddleware
+1.3.8: Keep query string when switching locales


### PR DESCRIPTION
should fix https://github.com/rainlab/translate-plugin/issues/336
