### PR TITLE
Fix issue where default texts are overwritten by import

### DIFF
--- a/models/MessageImport.php
+++ b/models/MessageImport.php
@@ -43,6 +43,10 @@ class MessageImport extends ImportModel
 
                     $message->message_data = array_merge($message->message_data, $result);
 
+                    if(!isset($message->message_data[Message::DEFAULT_LOCALE])) {
+                        $result[Message::DEFAULT_LOCALE] = $code;
+                    }
+
                     if ($message->exists) {
                         $this->logUpdated();
                     } else {

--- a/models/MessageImport.php
+++ b/models/MessageImport.php
@@ -35,7 +35,6 @@ class MessageImport extends ImportModel
                     $code = $result[$codeName];
                     // modify result to match the expected message_data schema
                     unset($result[$codeName]);
-                    $result[Message::DEFAULT_LOCALE] = $code;
 
                     $message = Message::firstOrNew(['code' => $code]);
 


### PR DESCRIPTION
When importing translated messages, default language (denoted by x) is currently overwritten with codes. Example:

Before import:

- Code = test.message 
- Default = Test Message

After import:

- Code = test.message
- Default = **test.message**


This PR fixes that issue, so that only translations are imported. Default language (usually coming directly from the template source code) is not changed.