### PR TITLE
PR: Fix position of the language switcher menu to remove UI overlap.

### DIFF
--- a/assets/css/multilingual.css
+++ b/assets/css/multilingual.css
@@ -55,13 +55,13 @@
   right: 12px;
 }
 .field-multilingual.field-multilingual-repeater .ml-btn {
-  top: -10px;
-  right: 50px;
+  top: -27px;
+  right: 11px;
   text-align: right;
 }
 .field-multilingual.field-multilingual-repeater .ml-dropdown-menu {
-  top: 15px;
-  right: 38px;
+  top: 0;
+  right: 0;
 }
 .field-multilingual.field-multilingual-repeater.is-empty {
   padding-top: 5px;

--- a/assets/less/multilingual.less
+++ b/assets/less/multilingual.less
@@ -77,14 +77,14 @@
 
     &.field-multilingual-repeater {
         .ml-btn {
-            top: -10px;
-            right: 50px;
+            top: -27px;
+            right: 11px;
             text-align: right;
         }
 
         .ml-dropdown-menu {
-            top: 15px;
-            right: 38px;
+            top: 0;
+            right: 0;
         }
 
         &.is-empty {


### PR DESCRIPTION
A PR to fix the position of the language switcher for translatable repeaters.

See following issue for more details:
https://github.com/rainlab/translate-plugin/issues/401