### PR TITLE
fix Message's cache

### DIFF
--- a/models/Message.php
+++ b/models/Message.php
@@ -107,8 +107,8 @@ class Message extends Model
         /*
          * Found in cache
          */
-        if (array_key_exists($messageCode, self::$cache)) {
-            return self::$cache[$messageCode];
+        if (array_key_exists(self::$locale . $messageCode, self::$cache)) {
+            return self::$cache[self::$locale . $messageCode];
         }
 
         /*
@@ -131,7 +131,7 @@ class Message extends Model
          * Schedule new cache and go
          */
         $msg = $item->forLocale(self::$locale, $messageId);
-        self::$cache[$messageCode] = $msg;
+        self::$cache[self::$locale . $messageCode] = $msg;
         self::$hasNew = true;
 
         return $msg;


### PR DESCRIPTION
Quite specific case. At a certain event of one user, the letter is sent to another user and this letter can be in different languages ​​depending on what the second user has set in the profile. If the message was sent to one user, then it went to the other in the same language regardless of the specified locale.