### PR TITLE
Explain how to make default translation effective

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ hr:
     nav.video: 'Video'
     title.home: 'Dobrodošli'
 ```
+
+In order to make these default values reflected to your frontend site, go to **Settings -> Translate messages** in the backend and hit **Scan for messages**. They will also be loaded automatically when the theme is activated.
+
 ## Content translation
 
 This plugin activates a feature in the CMS that allows content files to use language suffixes, for example:


### PR DESCRIPTION
Added explanation to README.md how to make default translation added in theme.yaml effective. I had to dig into the source code to figure it out. I wonder why no one has asked about this, though.