### PR TITLE
fix ctrl-click opening  new tab on firefox

### DIFF
--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -36,6 +36,7 @@
              * If Ctrl/Cmd key is pressed, find other instances and switch
              */
             if (event.ctrlKey || event.metaKey) {
+                event.preventDefault();
                 $('[data-switch-locale="'+selectedLocale+'"]').click()
             }
         })


### PR DESCRIPTION
Fixes #378 