### PR TITLE
Add ability for models to provide computed data

### DIFF
--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -84,8 +84,27 @@ class TranslatableModel extends TranslatableBehavior
             return;
         }
 
-        /*
-         * Resolve computed fields before saving...
+        /** 
+         * @event model.translate.resolveComputedFields
+         * Resolve computed fields before saving
+         *
+         * Example usage:
+         *
+         * Override Model's __construct method
+         *
+         * public function __construct(array $attributes = [])
+         * {
+         *     parent::__construct($attributes);
+         *
+         *     $this->bindEvent('model.translate.resolveComputedFields', function ($locale) {
+         *         return [
+         *             'content_html' =>
+         *                 self::formatHtml($this->asExtension('TranslatableModel')
+         *                     ->getAttributeTranslated('content', $locale))
+         *         ];
+         *     });
+         * }
+         *
          */
         $computedFields = $this->model->fireEvent('model.translate.resolveComputedFields', [$locale], true);
         if (is_array($computedFields))

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -107,8 +107,9 @@ class TranslatableModel extends TranslatableBehavior
          *
          */
         $computedFields = $this->model->fireEvent('model.translate.resolveComputedFields', [$locale], true);
-        if (is_array($computedFields))
+        if (is_array($computedFields)) {
             $this->translatableAttributes[$locale] = array_merge($this->translatableAttributes[$locale], $computedFields);
+        }
 
         $this->storeTranslatableBasicData($locale);
         $this->storeTranslatableIndexData($locale);

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -84,6 +84,13 @@ class TranslatableModel extends TranslatableBehavior
             return;
         }
 
+        /*
+         * Resolve computed fields before saving...
+         */
+        $computedFields = $this->model->fireEvent('model.translate.resolveComputedFields', [$locale], true);
+        if (is_array($computedFields))
+            $this->translatableAttributes[$locale] = array_merge($this->translatableAttributes[$locale], $computedFields);
+
         $this->storeTranslatableBasicData($locale);
         $this->storeTranslatableIndexData($locale);
     }


### PR DESCRIPTION
Hello,

I've lately come across an undesired behaviour with blog plugin (https://github.com/rainlab/blog-plugin/issues/299). As I've explained in the issue, the field content_html is "computed" from the content field in the beforeSave function and the translated value **does not get updated**.

This, however, is true only if you don't use the original MLBlogMarkdown control because it currently has the logic of computing content_html field implemented internally. 

I've tried to come up with the most reasonable solution and my best implementation so far would be to fire an event, before saving translation data, that can provide computed values which then would be added to the translated attributes array.

The counterpart to this implementation in subclasses of Model would look like this:

```
public function __construct(array $attributes = [])
{
    parent::__construct($attributes);

    $this->bindEvent('model.translate.resolveComputedFields', function ($locale) {
        return [
            'content_html' =>
                self::formatHtml(
                    $this->asExtension('TranslatableModel')
                        ->getAttributeTranslated('content', $locale))
        ];
    });
}
```

Thanks for consideration and feedback.
Daniel