### PR TITLE
Locale model: lists deprecated, pluck instead

### DIFF
--- a/models/Locale.php
+++ b/models/Locale.php
@@ -168,7 +168,7 @@ class Locale extends Model
             return self::$cacheListAvailable;
         }
 
-        return self::$cacheListAvailable = self::order()->lists('name', 'code');
+        return self::$cacheListAvailable = self::order()->pluck('name', 'code');
     }
 
     /**


### PR DESCRIPTION
In Locale model lists() is used, but it's deprecated since Laravel 5.3