### PR TITLE
fix translatable behavior event hooks

### DIFF
--- a/behaviors/TranslatablePage.php
+++ b/behaviors/TranslatablePage.php
@@ -29,6 +29,15 @@ class TranslatablePage extends TranslatableBehavior
         });
     }
 
+    public function isTranslatable($key)
+    {
+        if ($this->translatableDefault == $this->translatableContext) {
+            return false;
+        }
+
+        return in_array($key, $this->model->translatable);
+    }
+
     public function getTranslatableAttributes()
     {
         $attributes = [];
@@ -63,7 +72,8 @@ class TranslatablePage extends TranslatableBehavior
             $locale_attr = $this->translatableOriginals[$attr];
 
             if ($locale != $this->translatableDefault) {
-                $locale_attr = $this->getAttributeTranslated($attr, $locale) ?: $locale_attr;
+                $translated = $this->getAttributeTranslated($attr, $locale);
+                $locale_attr = $translated ?: $this->translatableUseFallback ? $locale_attr : null;
             }
 
             $this->model[$attr] = $locale_attr;
@@ -78,11 +88,7 @@ class TranslatablePage extends TranslatableBehavior
             // retrieve attr name within brackets (i.e. settings[title] yields title)
             $key = preg_split("/[\[\]]/", $key)[1];
         }
-
-        if (!$this->translatableOriginals[$key]) {
-            $this->translatableOriginals = $this->getModelAttributes();
-        }
-        $default = ($locale == $this->translatableDefault) ? $this->translatableOriginals[$key] : null;
+        $default = ($locale == $this->translatableDefault || $this->translatableUseFallback) ? $this->translatableOriginals[$key] : '';
 
         $locale_attr = sprintf('viewBag.locale%s.%s', ucfirst($key), $locale);
         return array_get($this->model->attributes, $locale_attr, $default);

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -59,13 +59,13 @@ abstract class TranslatableBehavior extends ExtensionBase
         $this->initTranslatableContext();
 
         $this->model->bindEvent('model.beforeGetAttribute', function($key) {
-            if ($key != 'translatable' && $this->isTranslatable($key)) {
+            if ($key !== 'translatable' && $this->isTranslatable($key)) {
                 return $this->getAttributeTranslated($key);
             }
         });
 
         $this->model->bindEvent('model.beforeSetAttribute', function($key, $value) {
-            if ($key != 'translatable' && $this->isTranslatable($key)) {
+            if ($key !== 'translatable' && $this->isTranslatable($key)) {
                 return $this->setAttributeTranslated($key, $value);
             }
         });

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -59,13 +59,13 @@ abstract class TranslatableBehavior extends ExtensionBase
         $this->initTranslatableContext();
 
         $this->model->bindEvent('model.beforeGetAttribute', function($key) {
-            if ($this->isTranslatable($key)) {
+            if ($key != 'translatable' && $this->isTranslatable($key)) {
                 return $this->getAttributeTranslated($key);
             }
         });
 
         $this->model->bindEvent('model.beforeSetAttribute', function($key, $value) {
-            if ($this->isTranslatable($key)) {
+            if ($key != 'translatable' && $this->isTranslatable($key)) {
                 return $this->setAttributeTranslated($key, $value);
             }
         });

--- a/tests/fixtures/classes/TranslatablePage.php
+++ b/tests/fixtures/classes/TranslatablePage.php
@@ -1,0 +1,8 @@
+<?php namespace RainLab\Translate\Tests\Fixtures\Classes;
+
+use Cms\Classes\Page;
+
+class TranslatablePage extends Page
+{
+    protected $dirName = 'pages';
+}

--- a/tests/unit/behaviors/TranslatablePageTest.php
+++ b/tests/unit/behaviors/TranslatablePageTest.php
@@ -1,0 +1,66 @@
+<?php namespace RainLab\Translate\Tests\Unit\Behaviors;
+
+use File;
+use October\Rain\Halcyon\Model;
+use October\Rain\Filesystem\Filesystem;
+use October\Rain\Halcyon\Datasource\FileDatasource;
+use October\Rain\Halcyon\Datasource\Resolver;
+use RainLab\Translate\Tests\Fixtures\Classes\TranslatablePage;
+use PluginTestCase;
+
+class TranslatablePageTest extends PluginTestCase
+{
+    public $themePath;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->themePath = __DIR__ . '/../../fixtures/themes/test';
+
+        $datasource = new FileDatasource($this->themePath, new Filesystem);
+        $resolver = new Resolver(['theme1' => $datasource]);
+        $resolver->setDefaultDatasource('theme1');
+        Model::setDatasourceResolver($resolver);
+
+        TranslatablePage::extend(function($page) {
+            if (!$page->isClassExtendedWith('RainLab\Translate\Behaviors\TranslatablePage')) {
+                $page->addDynamicProperty('translatable', ['title']);
+                $page->extendClassWith('RainLab\Translate\Behaviors\TranslatablePage');
+            }
+        });
+    }
+
+    public function tearDown()
+    {
+        File::deleteDirectory($this->themePath.'/pages');
+    }
+
+    public function testUseFallback()
+    {
+        $page = TranslatablePage::create([
+            'fileName' => 'translatable',
+            'title' => 'english title',
+            'url' => '/test',
+        ]);
+        $page->translateContext('fr');
+        $this->assertEquals('english title', $page->title);
+        $page->noFallbackLocale()->translateContext('fr');
+        $this->assertEquals(null, $page->title);
+    }
+
+    public function testAlternateLocale()
+    {
+        $page = TranslatablePage::create([
+            'fileName' => 'translatable',
+            'title' => 'english title',
+            'url' => '/test',
+        ]);
+        $page->setAttributeTranslated('title', 'titre francais', 'fr');
+        $title_en = $page->title;
+        $this->assertEquals('english title', $title_en);
+        $page->translateContext('fr');
+        $title_fr = $page->title;
+        $this->assertEquals('titre francais', $title_fr);
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -52,4 +52,4 @@
 1.4.1: Updated Hungarian translation. Added Arabic translation. Fixed issue where default texts are overwritten by import. Fixed issue where the language switcher for repeater fields would overlap with the first repeater row.
 1.4.2: Add multilingual MediaFinder
 1.4.3: !!! Please update OctoberCMS to Build 444 before updating this plugin. Added ability to translate CMS Pages fields (e.g. title, description, meta-title, meta-description)
-1.4.4: Fix for the translatable dynamic property to be accessible in front-end.
+1.4.4: Fixed issue when using the language switcher

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -52,3 +52,4 @@
 1.4.1: Updated Hungarian translation. Added Arabic translation. Fixed issue where default texts are overwritten by import. Fixed issue where the language switcher for repeater fields would overlap with the first repeater row.
 1.4.2: Add multilingual MediaFinder
 1.4.3: !!! Please update OctoberCMS to Build 444 before updating this plugin. Added ability to translate CMS Pages fields (e.g. title, description, meta-title, meta-description)
+1.4.4: Fix for the translatable dynamic property to be accessible in front-end.


### PR DESCRIPTION
The TranslatableBehavior class prevents the getter/setter for "translatable" dynamic property to work when hooking to the model.beforeGetAttribute / model.beforeSetAttribute events.

This PR fix the issue by ignoring the hook when the key == 'translatable"

 