### PR TITLE
Fix array error when extending CMS Page original translatable attributes

### DIFF
--- a/behaviors/TranslatablePage.php
+++ b/behaviors/TranslatablePage.php
@@ -88,7 +88,7 @@ class TranslatablePage extends TranslatableBehavior
             // retrieve attr name within brackets (i.e. settings[title] yields title)
             $key = preg_split("/[\[\]]/", $key)[1];
         }
-        $default = ($locale == $this->translatableDefault || $this->translatableUseFallback) ? $this->translatableOriginals[$key] : '';
+        $default = ($locale == $this->translatableDefault || $this->translatableUseFallback) ? array_get($this->translatableOriginals, $key) : '';
 
         $locale_attr = sprintf('viewBag.locale%s.%s', ucfirst($key), $locale);
         return array_get($this->model->attributes, $locale_attr, $default);
@@ -107,7 +107,7 @@ class TranslatablePage extends TranslatableBehavior
             $key = preg_split("/[\[\]]/", $key)[1];
         }
 
-        if ($value == $this->translatableOriginals[$key]) {
+        if ($value == array_get($this->translatableOriginals, $key)) {
             return;
         }
 


### PR DESCRIPTION
I extend CMS Page translatable attributes with custom SEO fields like `og_title`,  `og_description`.

Before this change I get array access error when to try create new CMS Page. The value of `$this->translatableOriginals[$key]`does not exists for key `og_title`.

After change the error does not appear and everything works as expected. I just check if value for the key exists, if so then it will return value for that key the same as before and if not `array_get` function will return `null`.