### PR TITLE
Fix for #209

### DIFF
--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -240,9 +240,10 @@ abstract class TranslatableBehavior extends ExtensionBase
     {
         // empty translatableAttributes when called from a related model 
         if (!$this->translatableAttributes && post('RLTranslate')) {
+            $translatable = $this->model->getTranslatableAttributes();
             foreach (post("RLTranslate") as $locale => $data) {
                 foreach ($data as $key => $value) {
-                    if ($this->isTranslatable($key)) {
+                    if (in_array($key, $translatable)) {
                         $this->setAttributeTranslated($key, $value, $locale);
                     }
                 }

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -242,7 +242,9 @@ abstract class TranslatableBehavior extends ExtensionBase
         if (!$this->translatableAttributes && post('RLTranslate')) {
             foreach (post("RLTranslate") as $locale => $data) {
                 foreach ($data as $key => $value) {
-                    $this->setAttributeTranslated($key, $value, $locale);
+                    if ($this->isTranslatable($key)) {
+                        $this->setAttributeTranslated($key, $value, $locale);
+                    }
                 }
             }
         }

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -238,6 +238,15 @@ abstract class TranslatableBehavior extends ExtensionBase
      */
     public function syncTranslatableAttributes()
     {
+        // empty translatableAttributes when called from a related model 
+        if (!$this->translatableAttributes && post('RLTranslate')) {
+            foreach (post("RLTranslate") as $locale => $data) {
+                foreach ($data as $key => $value) {
+                    $this->setAttributeTranslated($key, $value, $locale);
+                }
+            }
+        }
+
         /*
          * Spin through the known locales, store the translations if necessary
          */


### PR DESCRIPTION
When the model.saveInternal event is fired on a related model update without a form controller, translatable attributes are not set.

This calls the setAttributeTranslated() method for each entry in post('RLTranslate')