### PR TITLE
Handle oc.inputPreset.beforeUpdate event

### DIFF
--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -51,6 +51,21 @@
         this.activeLocale = this.options.defaultLocale
         this.$activeField = this.getLocaleElement(this.activeLocale)
         this.$activeButton.text(this.activeLocale)
+
+        /*
+         * Handle oc.inputPreset.beforeUpdate event
+         */
+        $('[data-input-preset]', this.$el).on('oc.inputPreset.beforeUpdate', function(event, inputPreset, src) {
+            var sourceLocale = src.siblings('.ml-btn[data-active-locale]').text()
+            var targetLocale = $(this).data('locale-value')
+            var targetActiveLocale = $(this).siblings('.ml-btn[data-active-locale]').text()
+
+            if (sourceLocale && targetLocale && sourceLocale !== targetLocale)
+                inputPreset.cancelled = true
+
+            if (inputPreset.cancelled === false && targetLocale && targetActiveLocale && targetActiveLocale !== targetLocale)
+                $(this).siblings('.ml-btn[data-active-locale]').text(targetLocale)
+        })
     }
 
     MultiLingual.DEFAULTS = {

--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -60,12 +60,12 @@
             var targetLocale = $(this).data('locale-value')
             var targetActiveLocale = $(this).siblings('.ml-btn[data-active-locale]').text()
 
-            // set input-preset field updatability when its locale is not the src locale
-            if (sourceLocale && targetLocale && sourceLocale !== targetLocale)
-                $(this).data('update', false)
-
-            if ($(this).data('update') !== false && targetLocale && targetActiveLocale && targetActiveLocale !== targetLocale)
-                $(this).siblings('.ml-btn[data-active-locale]').text(targetLocale)
+            if (sourceLocale && targetLocale && targetActiveLocale) {
+                if (sourceLocale !== targetLocale)
+                    $(this).data('update', false)
+                else if (targetActiveLocale !== targetLocale)
+                    $(this).siblings('.ml-btn[data-active-locale]').text(targetLocale)
+            }
         })
     }
 
@@ -102,7 +102,7 @@
         this.$placeholder.val(this.getLocaleValue(locale))
         this.$el.trigger('setLocale.oc.multilingual', [locale, this.getLocaleValue(locale)])
         // reset input-preset fields updatability attribute
-        $('[data-input-preset]', this.$el).data('update', true)
+        $('[data-input-preset]').data('update', true)
     }
 
     // MULTILINGUAL PLUGIN DEFINITION

--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -55,15 +55,15 @@
         /*
          * Handle oc.inputPreset.beforeUpdate event
          */
-        $('[data-input-preset]', this.$el).on('oc.inputPreset.beforeUpdate', function(event, inputPreset, src) {
+        $('[data-input-preset]', this.$el).on('oc.inputPreset.beforeUpdate', function(event, src) {
             var sourceLocale = src.siblings('.ml-btn[data-active-locale]').text()
             var targetLocale = $(this).data('locale-value')
             var targetActiveLocale = $(this).siblings('.ml-btn[data-active-locale]').text()
 
             if (sourceLocale && targetLocale && sourceLocale !== targetLocale)
-                inputPreset.cancelled = true
+                $(this).data('update', false)
 
-            if (inputPreset.cancelled === false && targetLocale && targetActiveLocale && targetActiveLocale !== targetLocale)
+            if ($(this).data('update') !== false && targetLocale && targetActiveLocale && targetActiveLocale !== targetLocale)
                 $(this).siblings('.ml-btn[data-active-locale]').text(targetLocale)
         })
     }

--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -61,10 +61,9 @@
             var targetActiveLocale = $(this).siblings('.ml-btn[data-active-locale]').text()
 
             if (sourceLocale && targetLocale && targetActiveLocale) {
-                if (sourceLocale !== targetLocale)
-                    $(this).data('update', false)
-                else if (targetActiveLocale !== targetLocale)
-                    $(this).siblings('.ml-btn[data-active-locale]').text(targetLocale)
+                if (targetActiveLocale !== sourceLocale)
+                    self.setLocale(sourceLocale)
+                $(this).data('update', sourceLocale === targetLocale)
             }
         })
     }
@@ -101,8 +100,6 @@
 
         this.$placeholder.val(this.getLocaleValue(locale))
         this.$el.trigger('setLocale.oc.multilingual', [locale, this.getLocaleValue(locale)])
-        // reset input-preset fields updatability attribute
-        $('[data-input-preset]').data('update', true)
     }
 
     // MULTILINGUAL PLUGIN DEFINITION

--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -60,6 +60,7 @@
             var targetLocale = $(this).data('locale-value')
             var targetActiveLocale = $(this).siblings('.ml-btn[data-active-locale]').text()
 
+            // set input-preset field updatability when its locale is not the src locale
             if (sourceLocale && targetLocale && sourceLocale !== targetLocale)
                 $(this).data('update', false)
 
@@ -100,6 +101,8 @@
 
         this.$placeholder.val(this.getLocaleValue(locale))
         this.$el.trigger('setLocale.oc.multilingual', [locale, this.getLocaleValue(locale)])
+        // reset input-preset fields updatability attribute
+        $('[data-input-preset]', this.$el).data('update', true)
     }
 
     // MULTILINGUAL PLUGIN DEFINITION


### PR DESCRIPTION
This change handle the new 'oc.inputPreset.beforeUpdate' event triggered by OctoberCMS core in modules/system/assets/ui/js/input.preset.js

ref. https://github.com/octobercms/october/pull/4217