### PR TITLE
prevent nested field names from matching Model->translatable[] fields

### DIFF
--- a/classes/EventRegistry.php
+++ b/classes/EventRegistry.php
@@ -87,7 +87,7 @@ class EventRegistry
             return;
         }
 
-        if (!empty($widget->config->fields) && !$widget->config->isNested) {
+        if (!empty($widget->config->fields) && !$widget->isNested) {
             $widget->fields = $this->processFormMLFields($widget->fields, $model);
         }
 

--- a/classes/EventRegistry.php
+++ b/classes/EventRegistry.php
@@ -87,7 +87,7 @@ class EventRegistry
             return;
         }
 
-        if (!empty($widget->config->fields)) {
+        if (!empty($widget->config->fields) && !$widget->config->isNested) {
             $widget->fields = $this->processFormMLFields($widget->fields, $model);
         }
 


### PR DESCRIPTION
Repeater and NestedForm formwidgets' field names are marked as translatable when they should when their name matches another field name from the model.

Fix #459