### PR TITLE
Fix post value rewrite

### DIFF
--- a/formwidgets/MLRepeater.php
+++ b/formwidgets/MLRepeater.php
@@ -165,9 +165,11 @@ class MLRepeater extends Repeater
 
         $indexVar = self::INDEX_PREFIX.implode('.', HtmlHelper::nameToArray($this->formField->getName(false)));
         $groupVar = self::GROUP_PREFIX.implode('.', HtmlHelper::nameToArray($this->formField->getName(false)));
-
-        array_set($_POST, $indexVar, $loadedIndexes);
-        array_set($_POST, $groupVar, $loadedGroups);
+        
+        $requestData = Request::all();
+        array_set($requestData, $indexVar, $loadedIndexes);
+        array_set($requestData, $groupVar, $loadedGroups);
+        Request::merge($requestData);
 
         $this->processExistingItems();
     }

--- a/formwidgets/MLRepeater.php
+++ b/formwidgets/MLRepeater.php
@@ -4,6 +4,7 @@ use Backend\FormWidgets\Repeater;
 use RainLab\Translate\Models\Locale;
 use October\Rain\Html\Helper as HtmlHelper;
 use ApplicationException;
+use Request;
 
 /**
  * ML Repeater
@@ -221,6 +222,9 @@ class MLRepeater extends Repeater
          */
         $data = $this->getPrimarySaveDataAsArray();
         $fieldName = 'RLTranslate.'.$locale.'.'.implode('.', HtmlHelper::nameToArray($this->fieldName));
-        array_set($_POST, $fieldName, json_encode($data));
+        
+        $requestData = Request::all();
+        array_set($requestData, $fieldName, json_encode($data));
+        Request::merge($requestData);
     }
 }


### PR DESCRIPTION
Due to a recent change in https://github.com/octobercms/library, changing the $_POST superglobal directly doesn't work any more. 

The issue is described more in detail here: https://github.com/octobercms/library/commit/fd839047c2d7757f225a8ed60673ca8a20fe7df4