### PR TITLE
MLFileUpload widget enables translation of file captions

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -5,6 +5,7 @@ use Event;
 use Backend;
 use Cms\Classes\Page;
 use System\Classes\PluginBase;
+use System\Models\File;
 use RainLab\Translate\Models\Message;
 use RainLab\Translate\Classes\EventRegistry;
 use Exception;
@@ -46,6 +47,17 @@ class Plugin extends PluginBase
             $page->addDynamicProperty('translatable', ['title', 'description', 'meta_title', 'meta_description']);
             $page->extendClassWith('RainLab\Translate\Behaviors\TranslatablePageUrl');
             $page->extendClassWith('RainLab\Translate\Behaviors\TranslatablePage');
+        });
+
+        /*
+         * Handle translatable file title and description
+         */
+        File::extend(function($file) {
+            $file->extendClassWith('RainLab\Translate\Behaviors\TranslatableModel');
+            $file->addDynamicProperty('translatable', ['title', 'description']);
+            //see https://github.com/octobercms/october/issues/3433
+            $file->extendClassWith('October\Rain\Database\Behaviors\Purgeable');
+            $file->addDynamicProperty('purgeable', ['translatable']);
         });
     }
 
@@ -171,6 +183,7 @@ class Plugin extends PluginBase
             'RainLab\Translate\FormWidgets\MLMarkdownEditor' => 'mlmarkdowneditor',
             'RainLab\Translate\FormWidgets\MLRepeater' => 'mlrepeater',
             'RainLab\Translate\FormWidgets\MLMediaFinder' => 'mlmediafinder',
+            'RainLab\Translate\FormWidgets\MLFileUpload' => 'mlfileupload',
         ];
     }
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ By default, untranslated attributes will fall back to the default locale. This b
 
 ## Indexed attributes
 
-Translatable model attributes can also be declared as an index by passing the `$transatable` attribute value as an array. The first value is the attribute name, the other values represent options, in this case setting the option `index` to `true`.
+Translatable model attributes can also be declared as an index by passing the `$translatable` attribute value as an array. The first value is the attribute name, the other values represent options, in this case setting the option `index` to `true`.
 
         public $translatable = [
             'name',
@@ -172,6 +172,23 @@ Once an attribute is indexed, you may use the `transWhere` method to apply a bas
 The `transWhere` method accepts a third argument to explicitly pass a locale value, otherwise it will be detected from the environment.
 
     Post::transWhere('slug', 'hello-world', 'en')->first();
+
+## File attachments captions
+
+File attachments can have their captions translated by specifying their key names in the `$translatable` attribute.
+
+    public $attachOne = [
+        'avatar' => 'System\Models\File'
+    ];
+
+    public $attachMany = [
+        'photos' => 'System\Models\File'
+    ];    
+
+    public $translatable = [
+        'name', 'avatar', 'photos'
+    ];
+
 
 ## URL translation
 

--- a/classes/EventRegistry.php
+++ b/classes/EventRegistry.php
@@ -142,6 +142,9 @@ class EventRegistry
             elseif ($type == 'mediafinder') {
                 $fields[$name]['type'] = 'mlmediafinder';
             }
+            elseif ($type == 'fileupload') {
+                $fields[$name]['type'] = 'mlfileupload';
+            }
         }
 
         return $fields;

--- a/formwidgets/MLFileUpload.php
+++ b/formwidgets/MLFileUpload.php
@@ -1,0 +1,74 @@
+<?php namespace RainLab\Translate\FormWidgets;
+
+use Backend\FormWidgets\FileUpload;
+
+/**
+ * ML FileUpload
+ * Renders a multi-lingual form file uploader field.
+ *
+ * @package rainlab\translate
+ * @author Adrien Girbone, Maria Vilaró
+ */
+class MLFileUpload extends FileUpload
+{
+    use \RainLab\Translate\Traits\MLControl;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $defaultAlias = 'mlfileupload';
+
+    public function init()
+    {
+        parent::init();
+        $this->initLocale();
+
+        $viewPath = [];
+        if ($this->isAvailable) {
+            $viewPath[] = $this->getViewPaths()[0];
+        }
+
+        $viewPath[] = $this->guessViewPathFrom(get_parent_class($this), '/partials');
+
+        $this->addViewPath($viewPath);
+    }
+
+    protected function loadAssets()
+    {
+        $this->assetPath = $this->guessViewPathFrom(get_parent_class($this), '/assets', true);
+        parent::loadAssets();
+    }
+
+    /**
+     * Loads the configuration form for an attachment, allowing title and description to be set.
+     */
+    public function onLoadAttachmentConfig()
+    {
+        $this->prepareLocaleVars();
+        return parent::onLoadAttachmentConfig();
+    }
+
+    /**
+     * Commit the changes of the attachment configuration form.
+     */
+    public function onSaveAttachmentConfig()
+    {
+        try {
+            $fileModel = $this->getRelationModel();
+            if (($fileId = post('file_id')) && ($file = $fileModel::find($fileId))) {
+                foreach(post('MLFileTranslate') as $code => $attrs) {
+                    foreach($attrs as $k => $v) {
+                        $file->lang($code)->$k = $v;
+                    }
+                    $file->lang($code)->save();
+                }
+                $file->save();
+                return ['displayName' => $file->lang($this->defaultLocale->code)->title ?: $file->lang($this->defaultLocale->code)->file_name];
+            }
+            throw new ApplicationException('Unable to find file, it may no longer exist');
+        }
+        catch (Exception $ex) {
+            return json_encode(['error' => $ex->getMessage()]);
+        }
+    }
+}

--- a/formwidgets/mlfileupload/partials/_config_form.htm
+++ b/formwidgets/mlfileupload/partials/_config_form.htm
@@ -1,0 +1,93 @@
+<div class="fileupload-config-form">
+    <?= Form::open() ?>
+        <input type="hidden" name="file_id" value="<?= $file->id ?>" />
+        <input type="hidden" name="manage_id" value="<?= $relationManageId ?>" />
+        <input type="hidden" name="_relation_field" value="<?= $relationField ?>" />
+
+        <?php if (starts_with($displayMode, 'image')): ?>
+            <div class="file-upload-modal-image-header">
+                <button type="button" class="close" data-dismiss="popup">&times;</button>
+                <img
+                    src="<?= $file->thumbUrl ?>"
+                    class="img-responsive center-block"
+                    alt=""
+                    title="<?= e(trans('backend::lang.fileupload.attachment')) ?>: <?= e($file->file_name) ?>"
+                    style="<?= $cssDimensions ?>" />
+            </div>
+        <?php else: ?>
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="popup">&times;</button>
+                <h4 class="modal-title"><?= e(trans('backend::lang.fileupload.attachment')) ?>: <?= $file->file_name ?></h4>
+            </div>
+        <?php endif ?>
+        <div class="modal-body">
+            <p><?= e(trans('backend::lang.fileupload.help')) ?></p>
+
+            <div class="form-group">
+
+                <div
+                    data-control="multilingual"
+                    data-default-locale="<?= $defaultLocale->code ?>"
+                    data-placeholder-field="#MLFile-title-<?= $file->id ?>-placeholderField"
+                    class="field-multilingual field-multilingual-text dropdown">
+
+                    <input
+                        type="text"
+                        name="title"
+                        class="form-control"
+                        value="<?= $file->title ?>"
+                        placeholder="<?= e(trans('backend::lang.fileupload.title_label')) ?>"
+                        id="MLFile-title-<?= $file->id ?>-placeholderField"
+                    />
+
+                    <?= $this->makePartial('locale_button') ?>
+                    <?= $this->makePartial('locale_values', ['attribute' => 'title']) ?>
+                    <?= $this->makeMLPartial('locale_selector') ?>
+
+                </div>
+
+            </div>
+
+            <div class="form-group">
+
+                <div
+                    data-control="multilingual"
+                    data-default-locale="<?= $defaultLocale->code ?>"
+                    data-placeholder-field="#MLFile-description-<?= $file->id ?>-placeholderField"
+                    class="field-multilingual field-multilingual-textarea dropdown">
+
+                    <textarea
+                        name="description"
+                        placeholder="<?= e(trans('backend::lang.fileupload.description_label')) ?>"
+                        class="form-control"
+                        id="MLFile-description-<?= $file->id ?>-placeholderField"><?= $file->description ?></textarea>
+
+                    <?= $this->makePartial('locale_button') ?>
+                    <?= $this->makePartial('locale_values', ['attribute' => 'description']) ?>
+                    <?= $this->makeMLPartial('locale_selector') ?>
+
+                </div>
+
+            </div>
+
+        </div>
+        <div class="modal-footer">
+            <a href="<?= $file->pathUrl ?>" class="pull-left btn btn-link fileupload-url-button" target="_blank">
+                <i class="oc-icon-link"></i><?= e(trans('backend::lang.fileupload.attachment_url')) ?>
+            </a>
+            <button
+                type="submit"
+                class="btn btn-primary"
+                data-request="<?= $this->getEventHandler('onSaveAttachmentConfig') ?>"
+                data-popup-load-indicator>
+                <?= e(trans('backend::lang.form.save')) ?>
+            </button>
+            <button
+                type="button"
+                class="btn btn-default"
+                data-dismiss="popup">
+                <?= e(trans('backend::lang.form.cancel')) ?>
+            </button>
+        </div>
+    <?= Form::close() ?>
+</div>

--- a/formwidgets/mlfileupload/partials/_locale_button.htm
+++ b/formwidgets/mlfileupload/partials/_locale_button.htm
@@ -1,0 +1,6 @@
+<button
+    class="btn btn-default ml-btn"
+    data-toggle="dropdown"
+    data-active-locale
+    type="button">
+</button>

--- a/formwidgets/mlfileupload/partials/_locale_values.htm
+++ b/formwidgets/mlfileupload/partials/_locale_values.htm
@@ -1,0 +1,8 @@
+<?php foreach ($locales as $code => $name): ?>
+    <input
+    type="hidden"
+    name="MLFileTranslate[<?= $code; ?>][<?= $attribute; ?>]"
+    value="<?= $file->getAttributeTranslated($attribute, $code) ?>"
+    data-locale-value="<?= $code ?>"
+    />
+<?php endforeach ?>


### PR DESCRIPTION
I added a widget that enables translation of attached files captions (title and description). I used this code https://github.com/Glitchbone/octobercms-filetranslate-plugin with some changes and fixes.