### PR TITLE
Delete all cache to fix pages-plugin issue 326. Temp fix.

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -3,6 +3,7 @@
 use Lang;
 use Event;
 use Backend;
+use Cache;
 use Cms\Classes\Page;
 use System\Classes\PluginBase;
 use RainLab\Translate\Models\Message;
@@ -100,6 +101,17 @@ class Plugin extends PluginBase
         Event::listen('pages.page.getMenuCacheKey', $modifyKey);
         Event::listen('pages.snippet.getMapCacheKey', $modifyKey);
         Event::listen('pages.snippet.getPartialMapCacheKey', $modifyKey);
+
+
+        /**
+         * Delete all cache. Fixes following issue:
+         * https://github.com/rainlab/pages-plugin/issues/326
+         */
+        $clearAllPagesCache = function ($controller, $object, $type) {
+            Cache::clear();
+        };
+        Event::listen('pages.object.save', $clearAllPagesCache);
+
     }
 
     public function registerComponents()


### PR DESCRIPTION
Related to: https://github.com/rainlab/pages-plugin/issues/326

When you save the page in the backend, it only clears the mapping cache for your current language. Example cache key `2403172130snippet-map-nl`. So not `-en`, `-fr`, etc. But it is saving all language content files with updated snippet xml. 

```
        modified:   themes/theme/content/static-pages-de/index.htm
        modified:   themes/theme/content/static-pages-en/index.htm
        modified:   themes/theme/content/static-pages-fr/index.htm
        modified:   themes/theme/content/static-pages/index.htm
```

This is causing bugs.

In my case the figure tags originally contained a space between the tags (and in cache). Example:

```
<figure ……> </figure>
```

But after saving it in the backend, they contained `&nbsp`. 

```
<figure ……>&nbsp;</figure>
```

The frontend gets cache from non-default language with space (it is not cleared), tries to replace `&nbsp` figure tag in the markup with old space ` ` version. So blank pages at frontend. Nothing is replaced by `mb_ereg_replace` in `RainLab\Pages\Classes\Snippet::processPageMarkup` and the html contains raw `<figure>` tags.

I made a quickfix to clear all the cache. It **should** just clear all the language content cache files. But cache clearing happens in the pages plugin and we can only modify a (single) cache key. I think the pages plugin will need an event to extend cache clearing. Or something similar.

Hope this temporary fix is helpful for now. For us and our client it is! 
