### PR TITLE
Fixes issue with indexing

### DIFF
--- a/formwidgets/MLRepeater.php
+++ b/formwidgets/MLRepeater.php
@@ -64,7 +64,7 @@ class MLRepeater extends Repeater
     {
         $this->rewritePostValues();
 
-        return $this->getLocaleSaveValue($value);
+        return $this->getLocaleSaveValue(array_values($value));
     }
 
     /**


### PR DESCRIPTION
After update a project to the latest version: 454 data in static pages that use repeater disappear. This is because indexing start from not 0
```
slider[4][image] = "/HomePageSlider/home-page-1920x600-img1.2.jpg"
slider[4][title] = "Fourth Update on the Regional Strategy for Sustainable Hydropower in the Western Balkans"
slider[4][buttonText] = "Read More"
slider[4][buttonUrl] = "/news-details/fourth-update-regional-strategy-sustainable-hydropower-western-balkans"
slider[4][subtitleDate] = ""
slider[4][urlTarget] = "_self"
slider[5][image] = "/HomePageSlider/home-page-1920x600-img2.jpg"
slider[5][title] = "Start of the WBIF Technical Assistance for Bar – Boljare Highway Phase II on the Orient/East-Med Corridor in Montenegro"
slider[5][buttonText] = "Read More"
slider[5][buttonUrl] = "/news-details/start-wbif-technical-assistance-bar-boljare-highway-phase-ii"
slider[5][subtitleDate] = ""
slider[5][urlTarget] = "_self"
```

Steps to reproduce:
Install latest october with latest static page and translate plugin. add repeater to a layout:
```
{repeater name="content_sections" prompt="Add another content section"}
<h3>
    {text name="content_header" label="Content section" placeholder="Type in a heading and enter some content for it below"}{/text}
</h3>
<div>
    {richeditor name="content_body" size="large"}{/richeditor}
</div>
{/repeater}
```
add some items and then remove the first one. If you refresh the page some items will disappear because of the wrong indexing in the file of the static pages 
