### PR TITLE
add option to disable locale prefix routes

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -8,7 +8,6 @@ return [
     |
     | Should the default locale be prefixed by the plugin?
     |
-    |
     */
     'prefixDefaultLocale' => true,
 
@@ -30,7 +29,8 @@ return [
     | Disable locale prefix routes
     |--------------------------------------------------------------------------
     |
-    | Should we disable the locale prefix routes?
+    | Disables the automatically generated locale prefixed routes
+    | (i.e. /en/original-route) when enabled.
     |
     */
     'disableLocalePrefixRoutes' => false,

--- a/config/config.php
+++ b/config/config.php
@@ -8,7 +8,6 @@ return [
     |
     | Should the default locale be prefixed by the plugin?
     |
-    | ( For now only used in the alternate-hreflang component )
     |
     */
     'prefixDefaultLocale' => true,
@@ -25,5 +24,15 @@ return [
     |
     */
     'cacheTimeout'        => 1440,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Disable locale prefix routes
+    |--------------------------------------------------------------------------
+    |
+    | Should we disable the locale prefix routes?
+    |
+    */
+    'disableLocalePrefixRoutes' => false,
 
 ];

--- a/routes.php
+++ b/routes.php
@@ -8,6 +8,10 @@ use RainLab\Translate\Classes\Translator;
  */
 App::before(function($request) {
 
+    if (Config::get('rainlab.translate::disableLocalePrefixRoutes', false)) {
+        return;
+    }
+
     if (App::runningInBackend()) {
         return;
     }
@@ -19,10 +23,6 @@ App::before(function($request) {
         !$translator->loadLocaleFromRequest() ||
         (!$locale = $translator->getLocale())
     ) {
-        return;
-    }
-
-    if (Config::get('rainlab.translate::disableLocalePrefixRoutes', false)) {
         return;
     }
 

--- a/routes.php
+++ b/routes.php
@@ -22,6 +22,10 @@ App::before(function($request) {
         return;
     }
 
+    if (Config::get('rainlab.translate::disableLocalePrefixRoutes', false)) {
+        return;
+    }
+
     /*
      * Register routes
      */


### PR DESCRIPTION
New config to disable locale prefix routes (disableLocalePrefixRoutes). Defaults to false.

Resolves #476 