### PR TITLE
Per locale translate configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,23 @@ hr:
     title.home: 'Dobrodošli'
 ```
 
+You may also define the translations in a separate file PER LOCALE, where the path is relative to the theme. The following definition will source the default messages from the file **config/lang-en.yaml** inside the theme for the english locale and from the file **config/lang-fr.yaml for the french locale.
+
+    name: My Theme
+    # [...]
+
+    translate: 
+	en: config/lang-en.yaml
+	fr: config/lang-fr.yaml
+
+This is an example for the **config/lang-en.yaml** file:
+```
+site.name: 'My Website'
+nav.home: 'Home'
+nav.video: 'Video'
+title.home: 'Welcome Home'
+```
+
 In order to make these default values reflected to your frontend site, go to **Settings -> Translate messages** in the backend and hit **Scan for messages**. They will also be loaded automatically when the theme is activated.
 
 ## Content translation

--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -55,12 +55,18 @@ class ThemeScanner
         $keys = [];
 
         foreach ($config as $locale => $messages) {
+            if( is_string($messages) ) {
+                $messages = $theme->getConfigArray('translate.'.$locale);
+            }
             $keys = array_merge($keys, array_keys($messages));
         }
 
         Message::importMessages($keys);
 
         foreach ($config as $locale => $messages) {
+            if( is_string($messages) ) {
+                $messages = $theme->getConfigArray('translate.'.$locale);
+            }
             Message::importMessageCodes($messages, $locale);
         }
     }

--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -56,6 +56,7 @@ class ThemeScanner
 
         foreach ($config as $locale => $messages) {
             if (is_string($messages)) {
+                // $message is a yaml filename, load the yaml file
                 $messages = $theme->getConfigArray('translate.'.$locale);
             }
             $keys = array_merge($keys, array_keys($messages));
@@ -65,6 +66,7 @@ class ThemeScanner
 
         foreach ($config as $locale => $messages) {
             if (is_string($messages)) {
+                // $message is a yaml filename, load the yaml file
                 $messages = $theme->getConfigArray('translate.'.$locale);
             }
             Message::importMessageCodes($messages, $locale);

--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -55,7 +55,7 @@ class ThemeScanner
         $keys = [];
 
         foreach ($config as $locale => $messages) {
-            if( is_string($messages) ) {
+            if (is_string($messages)) {
                 $messages = $theme->getConfigArray('translate.'.$locale);
             }
             $keys = array_merge($keys, array_keys($messages));
@@ -64,7 +64,7 @@ class ThemeScanner
         Message::importMessages($keys);
 
         foreach ($config as $locale => $messages) {
-            if( is_string($messages) ) {
+            if (is_string($messages)) {
                 $messages = $theme->getConfigArray('translate.'.$locale);
             }
             Message::importMessageCodes($messages, $locale);


### PR DESCRIPTION
Resolves #262 

Allow specifying a yaml file PER LOCALE in theme.yaml "translate" section. e.g.:
```
translate:
   en: lang-en.yaml
   fr: lang-fr.yaml
```

credit: @hocopor