### PR TITLE
Attribute model and translations morphMany relation

### DIFF
--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -31,15 +31,6 @@ class TranslatableModel extends TranslatableBehavior
         ];
     }
 
-    public function scopeTransWith($query)
-    {
-        $query->with([
-          'translations'
-        ]);
-
-        return $query;
-    }
-
     /**
      * Applies a translatable index to a basic query. This scope will join the index
      * table and cannot be executed more than once.

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -227,11 +227,11 @@ class TranslatableModel extends TranslatableBehavior
             return $this->translatableAttributes[$locale] = [];
         }
 
-        $obj = $this->model->translations->first(function ($value, $key) use($locale) {
+        $obj = $this->model->translations->first(function ($value, $key) use ($locale) {
             return $value->attributes['locale'] === $locale;
         });
 
-        $result = $obj ? json_decode($obj['attribute_data'], true) : [];
+        $result = $obj ? json_decode($obj->attribute_data, true) : [];
 
         return $this->translatableOriginals[$locale] = $this->translatableAttributes[$locale] = $result;
     }

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -21,6 +21,25 @@ use Exception;
  */
 class TranslatableModel extends TranslatableBehavior
 {
+    public function __construct($model)
+    {
+        parent::__construct($model);
+
+        $model->morphMany['translations'] = [
+            'RainLab\Translate\Models\Attribute',
+            'name' => 'model'
+        ];
+    }
+
+    public function scopeTransWith($query)
+    {
+        $query->with([
+          'translations'
+        ]);
+
+        return $query;
+    }
+
     /**
      * Applies a translatable index to a basic query. This scope will join the index
      * table and cannot be executed more than once.
@@ -84,7 +103,7 @@ class TranslatableModel extends TranslatableBehavior
             return;
         }
 
-        /** 
+        /**
          * @event model.translate.resolveComputedFields
          * Resolve computed fields before saving
          *
@@ -208,13 +227,11 @@ class TranslatableModel extends TranslatableBehavior
             return $this->translatableAttributes[$locale] = [];
         }
 
-        $obj = Db::table('rainlab_translate_attributes')
-            ->where('locale', $locale)
-            ->where('model_id', $this->model->getKey())
-            ->where('model_type', get_class($this->model))
-            ->first();
+        $obj = $this->model->translations->first(function ($value, $key) use($locale) {
+            return $value->attributes['locale'] === $locale;
+        });
 
-        $result = $obj ? json_decode($obj->attribute_data, true) : [];
+        $result = $obj ? json_decode($obj['attribute_data'], true) : [];
 
         return $this->translatableOriginals[$locale] = $this->translatableAttributes[$locale] = $result;
     }

--- a/models/Attribute.php
+++ b/models/Attribute.php
@@ -1,0 +1,18 @@
+<?php namespace RainLab\Translate\Models;
+
+use Model;
+
+/**
+ * Attribute Model
+ */
+class Attribute extends Model
+{
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = 'rainlab_translate_attributes';
+
+    public $morphTo = [
+        'model' => []
+    ];
+}

--- a/tests/unit/behaviors/TranslatableModelTest.php
+++ b/tests/unit/behaviors/TranslatableModelTest.php
@@ -101,4 +101,26 @@ class TranslatableModelTest extends PluginTestCase
         $this->assertEquals(['a', 'b', 'c'], $obj->states);
     }
 
+    public function testGetTranslationValueEagerLoading()
+    {
+        $this->recycleSampleData();
+
+        $obj = CountryModel::first();
+        $obj->translateContext('fr');
+        $obj->name = 'Australie';
+        $obj->states = ['a', 'b', 'c'];
+        $obj->save();
+
+        $objList = CountryModel::with([
+          'translations'
+        ])->get();
+
+        $obj = $objList[0];
+        $this->assertEquals('Australia', $obj->name);
+        $this->assertEquals(['NSW', 'ACT', 'QLD'], $obj->states);
+
+        $obj->translateContext('fr');
+        $this->assertEquals('Australie', $obj->name);
+        $this->assertEquals(['a', 'b', 'c'], $obj->states);
+    }
 }


### PR DESCRIPTION
TranslatableBehavior with a "translations" morphMany relation to the new Attribute model, so you can use the Eloquent eager loading, for example:

```php
public function scopeList($query)
     {
         return $query->with([
           'translations',
           'featured_image',
           'featured_image.translations',
         ]);
     }
```