### PR TITLE
Prevent from duplicate extending

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -45,8 +45,12 @@ class Plugin extends PluginBase
          */
         Page::extend(function($page) {
             $page->addDynamicProperty('translatable', ['title', 'description', 'meta_title', 'meta_description']);
-            $page->extendClassWith('RainLab\Translate\Behaviors\TranslatablePageUrl');
-            $page->extendClassWith('RainLab\Translate\Behaviors\TranslatablePage');
+            if (!$page->isClassExtendedWith('RainLab\Translate\Behaviors\TranslatablePageUrl')) {
+                $page->extendClassWith('RainLab\Translate\Behaviors\TranslatablePageUrl');
+            }
+            if (!$page->isClassExtendedWith('RainLab\Translate\Behaviors\TranslatablePage')) {
+                $page->extendClassWith('RainLab\Translate\Behaviors\TranslatablePage');
+            }
         });
 
         /*
@@ -54,8 +58,12 @@ class Plugin extends PluginBase
          */
         File::extend(function ($model) {
             $model->addDynamicProperty('translatable', ['title', 'description']);
-            $model->extendClassWith('October\Rain\Database\Behaviors\Purgeable');
-            $model->extendClassWith('RainLab\Translate\Behaviors\TranslatableModel');
+            if (!$model->isClassExtendedWith('October\Rain\Database\Behaviors\Purgeable')) {
+                $model->extendClassWith('October\Rain\Database\Behaviors\Purgeable');
+            }
+            if (!$model->isClassExtendedWith('RainLab\Translate\Behaviors\TranslatableModel')) {
+                $model->extendClassWith('RainLab\Translate\Behaviors\TranslatableModel');
+            }
         });
     }
 


### PR DESCRIPTION
While flushing model event listeners in `PluginTestCase.php` the plugin throws an exception that the class has already been extended. 

This fix will prevent the class from trying to extend it twice.

All in all, does anybody know why extending the class twice throws Exception instead of ignoring it and proceeding? :)