### PR TITLE
restore support for accessors & mutators

### DIFF
--- a/behaviors/TranslatablePage.php
+++ b/behaviors/TranslatablePage.php
@@ -31,7 +31,7 @@ class TranslatablePage extends TranslatableBehavior
 
     public function isTranslatable($key)
     {
-        if ($this->translatableDefault == $this->translatableContext) {
+        if ($key === 'translatable' || $this->translatableDefault == $this->translatableContext) {
             return false;
         }
 

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -63,7 +63,8 @@ abstract class TranslatableBehavior extends ExtensionBase
             if ($key !== 'translatable' && $this->isTranslatable($key)) {
                 $value = $this->getAttributeTranslated($key);
                 if ($model->hasGetMutator($key)) {
-                    $value = $model->{'get'.Str::studly($key).'Attribute'}($value);
+                    $method = 'get'.Str::studly($key).'Attribute';
+                    $value = $model->{$method}($value);
                 }
                 return $value;
             }
@@ -71,7 +72,12 @@ abstract class TranslatableBehavior extends ExtensionBase
 
         $this->model->bindEvent('model.beforeSetAttribute', function($key, $value) {
             if ($key !== 'translatable' && $this->isTranslatable($key)) {
-                return $this->setAttributeTranslated($key, $value);
+                $value = $this->setAttributeTranslated($key, $value);
+                if ($model->hasSetMutator($key)) {
+                    $method = 'set'.Str::studly($key).'Attribute';
+                    $value = $model->{$method}($value);
+                }
+                return $value;
             }
         });
 

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -70,7 +70,7 @@ abstract class TranslatableBehavior extends ExtensionBase
             }
         });
 
-        $this->model->bindEvent('model.beforeSetAttribute', function($key, $value) {
+        $this->model->bindEvent('model.beforeSetAttribute', function($key, $value) use ($model) {
             if ($key !== 'translatable' && $this->isTranslatable($key)) {
                 $value = $this->setAttributeTranslated($key, $value);
                 if ($model->hasSetMutator($key)) {

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -59,22 +59,22 @@ abstract class TranslatableBehavior extends ExtensionBase
 
         $this->initTranslatableContext();
 
-        $this->model->bindEvent('model.beforeGetAttribute', function($key) use ($model) {
+        $this->model->bindEvent('model.beforeGetAttribute', function ($key) use ($model) {
             if ($this->isTranslatable($key)) {
                 $value = $this->getAttributeTranslated($key);
                 if ($model->hasGetMutator($key)) {
-                    $method = 'get'.Str::studly($key).'Attribute';
+                    $method = 'get' . Str::studly($key) . 'Attribute';
                     $value = $model->{$method}($value);
                 }
                 return $value;
             }
         });
 
-        $this->model->bindEvent('model.beforeSetAttribute', function($key, $value) use ($model) {
+        $this->model->bindEvent('model.beforeSetAttribute', function ($key, $value) use ($model) {
             if ($this->isTranslatable($key)) {
                 $value = $this->setAttributeTranslated($key, $value);
                 if ($model->hasSetMutator($key)) {
-                    $method = 'set'.Str::studly($key).'Attribute';
+                    $method = 'set' . Str::studly($key) . 'Attribute';
                     $value = $model->{$method}($value);
                 }
                 return $value;

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -1,5 +1,6 @@
 <?php namespace RainLab\Translate\Classes;
 
+use Str;
 use RainLab\Translate\Classes\Translator;
 use October\Rain\Extension\ExtensionBase;
 use October\Rain\Html\Helper as HtmlHelper;
@@ -58,9 +59,13 @@ abstract class TranslatableBehavior extends ExtensionBase
 
         $this->initTranslatableContext();
 
-        $this->model->bindEvent('model.beforeGetAttribute', function($key) {
+        $this->model->bindEvent('model.beforeGetAttribute', function($key) use ($model) {
             if ($key !== 'translatable' && $this->isTranslatable($key)) {
-                return $this->getAttributeTranslated($key);
+                $value = $this->getAttributeTranslated($key);
+                if ($model->hasGetMutator($key)) {
+                    $value = $model->{'get'.Str::studly($key).'Attribute'}($value);
+                }
+                return $value;
             }
         });
 

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -60,7 +60,7 @@ abstract class TranslatableBehavior extends ExtensionBase
         $this->initTranslatableContext();
 
         $this->model->bindEvent('model.beforeGetAttribute', function($key) use ($model) {
-            if ($key !== 'translatable' && $this->isTranslatable($key)) {
+            if ($this->isTranslatable($key)) {
                 $value = $this->getAttributeTranslated($key);
                 if ($model->hasGetMutator($key)) {
                     $method = 'get'.Str::studly($key).'Attribute';
@@ -71,7 +71,7 @@ abstract class TranslatableBehavior extends ExtensionBase
         });
 
         $this->model->bindEvent('model.beforeSetAttribute', function($key, $value) use ($model) {
-            if ($key !== 'translatable' && $this->isTranslatable($key)) {
+            if ($this->isTranslatable($key)) {
                 $value = $this->setAttributeTranslated($key, $value);
                 if ($model->hasSetMutator($key)) {
                     $method = 'set'.Str::studly($key).'Attribute';
@@ -104,7 +104,7 @@ abstract class TranslatableBehavior extends ExtensionBase
      */
     public function isTranslatable($key)
     {
-        if ($this->translatableDefault == $this->translatableContext) {
+        if ($key === 'translatable' || $this->translatableDefault == $this->translatableContext) {
             return false;
         }
 


### PR DESCRIPTION
since the hook to the "model.beforeGetAttribute" event is returning a value, the model accessors/mutators were not triggered anymore.

fixes #353 