### PR TITLE
Add console command for scanning messages

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -57,6 +57,11 @@ class Plugin extends PluginBase
             $model->extendClassWith('October\Rain\Database\Behaviors\Purgeable');
             $model->extendClassWith('RainLab\Translate\Behaviors\TranslatableModel');
         });
+
+        /*
+         * Register console commands
+         */
+        $this->registerConsoleCommand('translate.scan', 'Rainlab\Translate\Console\ScanCommand');
     }
 
     public function boot()

--- a/console/ScanCommand.php
+++ b/console/ScanCommand.php
@@ -1,0 +1,38 @@
+<?php namespace Rainlab\Translate\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use RainLab\Translate\Classes\ThemeScanner;
+use RainLab\Translate\Models\Message;
+
+class ScanCommand extends Command
+{
+    protected $name = 'translate:scan';
+
+    protected $description = 'Scan theme localizations files for new messages.';
+
+    public function handle()
+    {
+        if ($this->option('purge')) {
+            $this->output->writeln('Purging messages...');
+            Message::truncate();
+        }
+
+        ThemeScanner::scan();
+        $this->output->success('Messages scanned successfully.');
+        $this->output->note('You may need to run cache:clear for updated messages to take effect.');
+    }
+
+    protected function getArguments()
+    {
+        return [];
+    }
+
+    protected function getOptions()
+    {
+        return [
+            ['purge', 'null', InputOption::VALUE_NONE, 'First purge existing messages.', null],
+        ];
+    }
+}

--- a/console/ScanCommand.php
+++ b/console/ScanCommand.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use RainLab\Translate\Classes\ThemeScanner;
 use RainLab\Translate\Models\Message;
 

--- a/console/ScanCommand.php
+++ b/console/ScanCommand.php
@@ -9,7 +9,7 @@ class ScanCommand extends Command
 {
     protected $name = 'translate:scan';
 
-    protected $description = 'Scan theme localizations files for new messages.';
+    protected $description = 'Scan theme localization files for new messages.';
 
     public function handle()
     {


### PR DESCRIPTION
This is useful for automated website deployment.
(Typically I will include this command in my deploy script for updating translations in case of a theme update).

The command is equivalent to the backend GUI.

Usage:
`php artisan translate:scan`
or for purging old messages first:
`php artisan translate:scan --purge`