### PR TITLE
Fixes "Unparenthesized `a ? b : c ? d : e` is deprecated"

### DIFF
--- a/behaviors/TranslatablePage.php
+++ b/behaviors/TranslatablePage.php
@@ -73,7 +73,7 @@ class TranslatablePage extends TranslatableBehavior
 
             if ($locale != $this->translatableDefault) {
                 $translated = $this->getAttributeTranslated($attr, $locale);
-                $locale_attr = $translated ?: $this->translatableUseFallback ? $locale_attr : null;
+                $locale_attr = ($translated ?: $this->translatableUseFallback) ? $locale_attr : null;
             }
 
             $this->model[$attr] = $locale_attr;


### PR DESCRIPTION
Adds explicit parentheses on nested ternary operators for PHP 7.4 support

https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.nested-ternary