### PR TITLE
keep search term when filtering-out translated content

### DIFF
--- a/controllers/Messages.php
+++ b/controllers/Messages.php
@@ -85,6 +85,7 @@ class Messages extends Controller
         $fromCode = post('locale_from', null);
         $toCode = post('locale_to', Locale::getDefault()->code);
         $this->hideTranslated = post('hide_translated', false);
+        $searchTerm = post('search');
 
         /*
          * Page vars
@@ -118,9 +119,10 @@ class Messages extends Controller
          */
         $dataSource = $widget->getDataSource();
 
-        $dataSource->bindEvent('data.getRecords', function($offset, $count) use ($selectedFrom, $selectedTo) {
+        $dataSource->bindEvent('data.getRecords', function($offset, $count) use ($selectedFrom, $selectedTo, $searchTerm) {
             $messages = $this->listMessagesForDatasource([
                 'offset' => $offset,
+                'search' => $searchTerm,
                 'count' => $count
             ]);
 


### PR DESCRIPTION
This has been annoying me for a while. Before, everytime you clicked the "hide translated" checkbox, the current filtering based on search term was lost. 