### PR TITLE
1.6.7: Introduce migration to patch existing indexes using morph map

### DIFF
--- a/updates/migrate_morphed_indexes.php
+++ b/updates/migrate_morphed_indexes.php
@@ -1,0 +1,32 @@
+<?php namespace RainLab\Translate\Updates;
+
+use Db;
+use October\Rain\Database\Relations\Relation;
+use October\Rain\Database\Updates\Migration;
+use RainLab\Translate\Models\Attribute;
+
+/**
+ * Because attributes are loaded using a proper morphMany relation starting from version 1.6.3,
+ * custom morph map aliases are now taken into account. This migration updates all existing
+ * model_types to use the registered alias.
+ *
+ * @see https://github.com/rainlab/translate-plugin/issues/539
+ */
+class MigrateMorphedIndexes extends Migration
+{
+    protected $table = 'rainlab_translate_indexes';
+
+    public function up()
+    {
+        foreach (Relation::$morphMap as $alias => $class) {
+            Db::table($this->table)->where('model_type', $class)->update(['model_type' => $alias]);
+        }
+    }
+
+    public function down()
+    {
+        foreach (Relation::$morphMap as $alias => $class) {
+            Db::table($this->table)->where('model_type', $alias)->update(['model_type' => $class]);
+        }
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -64,3 +64,6 @@
 1.6.6:
     - Introduce migration to patch existing translations using morph map
     - migrate_morphed_attributes.php
+1.6.7:
+    - Introduce migration to patch existing indexes using morph map
+    - migrate_morphed_indexes.php


### PR DESCRIPTION
As discussed with @daftspunk via Slack.

This adds a migration to migrate existing `rainlab_translate_indexes` values to use any registered morph map alises. 

This is the same problem that was already fixed in the `rainlab_translate_attributes` table in the previous version.