### PR TITLE
Locale facade

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -1,5 +1,7 @@
 <?php namespace RainLab\Translate;
 
+use App;
+use Illuminate\Foundation\AliasLoader;
 use Lang;
 use Event;
 use Backend;
@@ -33,6 +35,13 @@ class Plugin extends PluginBase
 
     public function register()
     {
+        $aliasLoader = AliasLoader::getInstance();
+        $aliasLoader->alias('LocaleModel', 'RainLab\Translate\Facades\Locale');
+
+        App::singleton('locale.class', function () {
+            return new Models\Locale();
+        });
+
         /*
          * Defer event with low priority to let others contribute before this registers.
          */

--- a/Plugin.php
+++ b/Plugin.php
@@ -17,6 +17,8 @@ use RainLab\Translate\Classes\Translator;
  */
 class Plugin extends PluginBase
 {
+    public $elevated = true;
+
     /**
      * Returns information about this plugin.
      *
@@ -36,10 +38,10 @@ class Plugin extends PluginBase
     public function register()
     {
         $aliasLoader = AliasLoader::getInstance();
-        $aliasLoader->alias('LocaleModel', 'RainLab\Translate\Facades\Locale');
+        $aliasLoader->alias('LocaleModel', '\RainLab\Translate\Facades\Locale');
 
         App::singleton('locale.class', function () {
-            return new Models\Locale();
+            return new \Rainlab\Translate\Models\Locale;
         });
 
         /*

--- a/Plugin.php
+++ b/Plugin.php
@@ -41,7 +41,7 @@ class Plugin extends PluginBase
         $aliasLoader->alias('LocaleModel', '\RainLab\Translate\Facades\Locale');
 
         App::singleton('locale.class', function () {
-            return new \Rainlab\Translate\Models\Locale;
+            return new \RainLab\Translate\Models\Locale;
         });
 
         /*

--- a/behaviors/TranslatableCmsObject.php
+++ b/behaviors/TranslatableCmsObject.php
@@ -1,6 +1,6 @@
 <?php namespace RainLab\Translate\Behaviors;
 
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 use RainLab\Translate\Classes\Translator;
 use RainLab\Translate\Classes\TranslatableBehavior;
 use October\Rain\Html\Helper as HtmlHelper;

--- a/classes/EventRegistry.php
+++ b/classes/EventRegistry.php
@@ -5,7 +5,7 @@ use File;
 use Cms\Classes\Page;
 use Cms\Classes\Content;
 use RainLab\Translate\Models\Message;
-use RainLab\Translate\Models\Locale as LocaleModel;
+use LocaleModel;
 use RainLab\Translate\Classes\Translator;
 use RainLab\Translate\Classes\ThemeScanner;
 use Exception;

--- a/classes/Translator.php
+++ b/classes/Translator.php
@@ -5,7 +5,7 @@ use Schema;
 use Session;
 use Request;
 use Config;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 
 /**
  * Translate class

--- a/components/AlternateHrefLangElements.php
+++ b/components/AlternateHrefLangElements.php
@@ -5,7 +5,7 @@ namespace Rainlab\Translate\Components;
 use Cms\Classes\ComponentBase;
 use Event;
 use RainLab\Translate\Classes\Translator;
-use RainLab\Translate\Models\Locale as LocaleModel;
+use LocaleModel;
 use October\Rain\Router\Router as RainRouter;
 
 class AlternateHrefLangElements extends ComponentBase

--- a/components/LocalePicker.php
+++ b/components/LocalePicker.php
@@ -4,7 +4,7 @@ use Event;
 use Config;
 use Request;
 use Redirect;
-use RainLab\Translate\Models\Locale as LocaleModel;
+use LocaleModel;
 use RainLab\Translate\Classes\Translator;
 use October\Rain\Router\Router as RainRouter;
 use Cms\Classes\ComponentBase;

--- a/controllers/Locales.php
+++ b/controllers/Locales.php
@@ -3,7 +3,7 @@
 use BackendMenu;
 use Backend\Classes\Controller;
 use System\Classes\SettingsManager;
-use RainLab\Translate\Models\Locale as LocaleModel;
+use LocaleModel;
 
 /**
  * Locales Back-end Controller

--- a/controllers/Messages.php
+++ b/controllers/Messages.php
@@ -8,7 +8,7 @@ use Request;
 use BackendMenu;
 use Backend\Classes\Controller;
 use RainLab\Translate\Models\Message;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 use RainLab\Translate\Classes\ThemeScanner;
 use System\Helpers\Cache as CacheHelper;
 use System\Classes\SettingsManager;

--- a/facades/Locale.php
+++ b/facades/Locale.php
@@ -1,0 +1,12 @@
+<?php namespace RainLab\Translate\Facades;
+
+use October\Rain\Support\Facade;
+
+class Locale extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     * @return string
+     */
+    protected static function getFacadeAccessor() { return 'locale.class'; }
+}

--- a/formwidgets/MLMarkdownEditor.php
+++ b/formwidgets/MLMarkdownEditor.php
@@ -1,7 +1,7 @@
 <?php namespace RainLab\Translate\FormWidgets;
 
 use Backend\FormWidgets\MarkdownEditor;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 
 /**
  * ML Markdown Editor

--- a/formwidgets/MLMediaFinder.php
+++ b/formwidgets/MLMediaFinder.php
@@ -1,7 +1,7 @@
 <?php namespace RainLab\Translate\FormWidgets;
 
 use Backend\FormWidgets\MediaFinder;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 use System\Classes\MediaLibrary;
 
 /**

--- a/formwidgets/MLRepeater.php
+++ b/formwidgets/MLRepeater.php
@@ -1,7 +1,7 @@
 <?php namespace RainLab\Translate\FormWidgets;
 
 use Backend\FormWidgets\Repeater;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 use October\Rain\Html\Helper as HtmlHelper;
 use ApplicationException;
 use Request;

--- a/formwidgets/MLRichEditor.php
+++ b/formwidgets/MLRichEditor.php
@@ -1,7 +1,7 @@
 <?php namespace RainLab\Translate\FormWidgets;
 
 use Backend\FormWidgets\RichEditor;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 
 /**
  * ML Rich Editor

--- a/formwidgets/MLText.php
+++ b/formwidgets/MLText.php
@@ -1,7 +1,7 @@
 <?php namespace RainLab\Translate\FormWidgets;
 
 use Backend\Classes\FormWidgetBase;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 
 /**
  * ML Text

--- a/formwidgets/MLTextarea.php
+++ b/formwidgets/MLTextarea.php
@@ -1,7 +1,7 @@
 <?php namespace RainLab\Translate\FormWidgets;
 
 use Backend\Classes\FormWidgetBase;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 
 /**
  * ML Textarea

--- a/models/Locale.php
+++ b/models/Locale.php
@@ -195,7 +195,7 @@ class Locale extends Model
      */
     public static function isValid($locale)
     {
-        $languages = array_keys(Locale::listEnabled());
+        $languages = array_keys(static::listEnabled());
 
         return in_array($locale, $languages);
     }

--- a/tests/unit/behaviors/TranslatableCmsObjectTest.php
+++ b/tests/unit/behaviors/TranslatableCmsObjectTest.php
@@ -6,7 +6,7 @@ use October\Rain\Filesystem\Filesystem;
 use October\Rain\Halcyon\Datasource\FileDatasource;
 use October\Rain\Halcyon\Datasource\Resolver;
 use RainLab\Translate\Tests\Fixtures\Classes\Feature as FeatureModel;
-use RainLab\Translate\Models\Locale as LocaleModel;
+use LocaleModel;
 use PluginTestCase;
 
 class TranslatableCmsObjectTest extends PluginTestCase

--- a/tests/unit/behaviors/TranslatableModelTest.php
+++ b/tests/unit/behaviors/TranslatableModelTest.php
@@ -4,7 +4,7 @@ use Schema;
 use PluginTestCase;
 use Model;
 use RainLab\Translate\Tests\Fixtures\Models\Country as CountryModel;
-use RainLab\Translate\Models\Locale as LocaleModel;
+use LocaleModel;
 use October\Rain\Database\Relations\Relation;
 
 class TranslatableModelTest extends PluginTestCase

--- a/tests/unit/models/MessageTest.php
+++ b/tests/unit/models/MessageTest.php
@@ -1,6 +1,6 @@
 <?php namespace RainLab\Translate\Tests\Unit\Models;
 
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 use RainLab\Translate\Models\Message;
 use PluginTestCase;
 use Model;

--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -1,7 +1,7 @@
 <?php namespace RainLab\Translate\Traits;
 
 use Str;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 use Backend\Classes\FormWidgetBase;
 use October\Rain\Html\Helper as HtmlHelper;
 

--- a/updates/builder_table_update_rainlab_translate_locales.php
+++ b/updates/builder_table_update_rainlab_translate_locales.php
@@ -1,6 +1,6 @@
 <?php namespace RainLab\Translate\Updates;
 
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 use Schema;
 use October\Rain\Database\Updates\Migration;
 

--- a/updates/seed_all_tables.php
+++ b/updates/seed_all_tables.php
@@ -1,7 +1,7 @@
 <?php namespace RainLab\Translate\Updates;
 
 use October\Rain\Database\Updates\Seeder;
-use RainLab\Translate\Models\Locale;
+use LocaleModel as Locale;
 
 class SeedAllTables extends Seeder
 {


### PR DESCRIPTION
This change allows another plugin to improve on the Rainlab.Translate plugin by only extending its Locale model to add/change to its behavior.

Here's a short example on how to modify the base Locale model to always return all locales when running in development mode:

- add the following to your plugin's register() method:

```
 \App::extend('locale.class', function() {
   return new Classes\Locale
});
```

- create your Locale class that extends Rainlab.Translate Locale model:

```
<?php namespace Author\Plugin\Classes;

use App;

class Locale extends \RainLab\Translate\Models\Locale
{
    public function scopeIsEnabled($query)
    {   
        if (App::environment === 'dev') {
            // always return all configured locales
            return $query;
        }
        return parent::scopeIsEnabled($query);
    }   

    public static function listEnabled()
    {   
        if (App::environment() === 'dev') {
            // bypass cache
            return self::isEnabled()->order()->pluck('name', 'code')->all();
        }

        return parent::listEnabled();
    }
}
```

