### PR TITLE
Fix for rainlab/translate-plugin#376

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -69,14 +69,23 @@ class Plugin extends PluginBase
         /*
          * Add translation support to theme settings
          */
-        ThemeData::extend(function ($model) {
+        ThemeData::extend(static function ($model) {
             $model->extendClassWith(TranslatableModel::class);
 
             if (!$model->propertyExists('translatable')) {
                 $model->addDynamicProperty('translatable', []);
             }
 
-            $model->bindEvent('model.afterFetch', function() use ($model) {
+            // For some reason translatable property may appear in model's attributes
+            // and this is undesired behavior. If it happens we need to unset the attribute to prevent
+            // 'Unexpected type of array when attempting to save attribute "translatable"' exception
+            $model->bindEvent('model.saveInternal', static function() use ($model) {
+                if (isset($model->attributes['translatable']) && is_array($model->attributes['translatable'])) {
+                    unset($model->attributes['translatable']);
+                }
+            });
+
+            $model->bindEvent('model.afterFetch', static function() use ($model) {
                 foreach ($model->getFormFields() as $id => $field) {
                     if (!empty($field['translatable'])) {
                         $model->translatable[] = $id;

--- a/Plugin.php
+++ b/Plugin.php
@@ -10,7 +10,6 @@ use System\Classes\PluginBase;
 use RainLab\Translate\Models\Message;
 use RainLab\Translate\Classes\EventRegistry;
 use RainLab\Translate\Classes\Translator;
-use RainLab\Translate\Behaviors\TranslatableModel;
 
 /**
  * Translate Plugin Information File
@@ -70,20 +69,12 @@ class Plugin extends PluginBase
          * Add translation support to theme settings
          */
         ThemeData::extend(static function ($model) {
-            $model->extendClassWith(TranslatableModel::class);
-
             if (!$model->propertyExists('translatable')) {
                 $model->addDynamicProperty('translatable', []);
             }
 
-            // For some reason `translatable` property may appear in model's attributes
-            // and this is an undesired behavior. If it happens we need to unset the attribute to prevent
-            // 'Unexpected type of array when attempting to save attribute "translatable"' exception
-            $model->bindEvent('model.saveInternal', static function() use ($model) {
-                if (isset($model->attributes['translatable']) && is_array($model->attributes['translatable'])) {
-                    unset($model->attributes['translatable']);
-                }
-            });
+            $model->extendClassWith('October\Rain\Database\Behaviors\Purgeable');
+            $model->extendClassWith('RainLab\Translate\Behaviors\TranslatableModel');
 
             $model->bindEvent('model.afterFetch', static function() use ($model) {
                 foreach ($model->getFormFields() as $id => $field) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -76,8 +76,8 @@ class Plugin extends PluginBase
                 $model->addDynamicProperty('translatable', []);
             }
 
-            // For some reason translatable property may appear in model's attributes
-            // and this is undesired behavior. If it happens we need to unset the attribute to prevent
+            // For some reason `translatable` property may appear in model's attributes
+            // and this is an undesired behavior. If it happens we need to unset the attribute to prevent
             // 'Unexpected type of array when attempting to save attribute "translatable"' exception
             $model->bindEvent('model.saveInternal', static function() use ($model) {
                 if (isset($model->attributes['translatable']) && is_array($model->attributes['translatable'])) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -5,10 +5,12 @@ use Event;
 use Backend;
 use Cms\Classes\Page;
 use System\Models\File;
+use Cms\Models\ThemeData;
 use System\Classes\PluginBase;
 use RainLab\Translate\Models\Message;
 use RainLab\Translate\Classes\EventRegistry;
 use RainLab\Translate\Classes\Translator;
+use RainLab\Translate\Behaviors\TranslatableModel;
 
 /**
  * Translate Plugin Information File
@@ -62,6 +64,25 @@ class Plugin extends PluginBase
             $model->translatable = array_merge($model->translatable, ['title', 'description']);
             $model->extendClassWith('October\Rain\Database\Behaviors\Purgeable');
             $model->extendClassWith('RainLab\Translate\Behaviors\TranslatableModel');
+        });
+
+        /*
+         * Add translation support to theme settings
+         */
+        ThemeData::extend(function ($model) {
+            $model->extendClassWith(TranslatableModel::class);
+
+            if (!$model->propertyExists('translatable')) {
+                $model->addDynamicProperty('translatable', []);
+            }
+
+            $model->bindEvent('model.afterFetch', function() use ($model) {
+                foreach ($model->getFormFields() as $id => $field) {
+                    if (!empty($field['translatable'])) {
+                        $model->translatable[] = $id;
+                    }
+                }
+            });
         });
 
         /*

--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ There are ways to get and set attributes without changing the context.
 
     // Sets a single translated attribute for a language
     $user->setAttributeTranslated('name', 'Jean-Claude', 'fr');
+    
+## Theme data translation
+
+It is also possible to translate theme customisation options. Just mark your form fields with `translatable` property and the plugin will take care about everything else:
+
+    tabs:
+      fields:
+        website_name:
+          tab: Info
+          label: Website Name
+          type: text
+          default: Your website name
+          translatable: true    
 
 ## Fallback attribute values
 


### PR DESCRIPTION
Fields are not marked as translatable by default.
It is a theme author responsibility to configure required fields via theme's config and mark fields as `translatable`.

For example:

```
tabs:
  fields:

    ####################################################
    # Tab: Info
    ####################################################

    website_name:
      tab: Info
      label: Website Name
      type: text
      default: Octaskin
      translatable: true
```

And the result is:

![image](https://user-images.githubusercontent.com/3897579/75448380-05abc900-5963-11ea-8526-e713e26b7a89.png)
