### PR TITLE
escape params when translating messages

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -238,6 +238,8 @@ class Plugin extends PluginBase
             'filters' => [
                 '_'  => [$this, 'translateString'],
                 '__' => [$this, 'translatePlural'],
+                'transRaw'  => [$this, 'translateRawString'],
+                'transRawPlural' => [$this, 'translateRawPlural'],
                 'localeUrl' => [$this, 'localeUrl'],
             ]
         ];
@@ -281,5 +283,15 @@ class Plugin extends PluginBase
     public function translatePlural($string, $count = 0, $params = [], $locale = null)
     {
         return Lang::choice(Message::trans($string, $params, $locale), $count, $params);
+    }
+
+    public function translateRawString($string, $params = [], $locale = null)
+    {
+        return Message::transRaw($string, $params, $locale);
+    }
+
+    public function translateRawPlural($string, $count = 0, $params = [], $locale = null)
+    {
+        return Lang::choice(Message::transRaw($string, $params, $locale), $count, $params);
     }
 }

--- a/models/Message.php
+++ b/models/Message.php
@@ -205,6 +205,26 @@ class Message extends Model
         $msg = static::get($messageId, $locale);
 
         $params = array_build($params, function($key, $value){
+            return [':'.$key, e($value)];
+        });
+
+        $msg = strtr($msg, $params);
+
+        return $msg;
+    }
+
+    /**
+     * Looks up and translates a message by its string WITHOUT escaping params.
+     * @param  string $messageId
+     * @param  array  $params
+     * @param  string $locale
+     * @return string
+     */
+    public static function transRaw($messageId, $params = [], $locale = null)
+    {
+        $msg = static::get($messageId, $locale);
+
+        $params = array_build($params, function($key, $value){
             return [':'.$key, $value];
         });
 


### PR DESCRIPTION
Fixes #553 

introduces transRaw() method for legacy usage