### PR TITLE
add rainlab.translate.messageCode event

### DIFF
--- a/models/Message.php
+++ b/models/Message.php
@@ -1,5 +1,6 @@
 <?php namespace RainLab\Translate\Models;
 
+use Event;
 use Str;
 use Lang;
 use Model;
@@ -282,6 +283,10 @@ class Message extends Model
      */
     protected static function makeMessageCode($messageId)
     {
+        if ($result = Event::fire('rainlab.translate.messageCode', [$messageId], true)) {
+            return $result;
+        }
+
         $separator = '.';
 
         // Convert all dashes/underscores into separator


### PR DESCRIPTION
Proposal to introduce an event to override how the messageCode is generated.

Usage example:
```
Event::listen('rainlab.translate.messageCode', function ($messageId) {
   return md5($messageId);
});
```