### PR TITLE
Add option to purge only deleted messages

### DIFF
--- a/assets/js/messages.js
+++ b/assets/js/messages.js
@@ -34,6 +34,11 @@
         this.toHeader = null
 
         /*
+         * Template for the "found" header (title)
+         */
+        this.foundHeader = null
+
+        /*
          * The table widget element
          */
         this.tableElement = null
@@ -76,14 +81,16 @@
             $toolbar.prepend(Mustache.render(this.tableToolbar.html()))
         }
 
-        this.setTitleContents = function(fromEl, toEl) {
+        this.setTitleContents = function(fromEl, toEl, foundEl) {
             if (fromEl) this.fromHeader = $(fromEl)
             if (toEl) this.toHeader = $(toEl)
+            if (foundEl) this.foundHeader = $(foundEl)
             if (!this.tableElement) return
 
             var $headers = $('table.headers th', this.tableElement)
             $headers.eq(0).html(this.fromHeader.html())
             $headers.eq(1).html(Mustache.render(this.toHeader.html(), { hideTranslated: this.hideTranslated } ))
+            $headers.eq(2).html(this.foundHeader.html())
         }
 
         this.setTableElement = function(el) {

--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -33,19 +33,13 @@ class ThemeScanner
      */
     public function scanForMessages()
     {
-        $this->setMessagesAsNotFound();
+        // Set all messages initially as being not found. The scanner later
+        // sets the entries it finds as found.
+        Message::query()->update(['found' => false]);
+
         $this->scanThemeConfigForMessages();
         $this->scanThemeTemplatesForMessages();
         $this->scanMailTemplatesForMessages();
-    }
-
-    /**
-     * Sets all current messages as not found
-     * @return void
-     */
-    public function setMessagesAsNotFound()
-    {
-        Message::query()->update(['found' => 0]);
     }
 
     /**

--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -33,9 +33,19 @@ class ThemeScanner
      */
     public function scanForMessages()
     {
+        $this->setMessagesAsNotFound();
         $this->scanThemeConfigForMessages();
         $this->scanThemeTemplatesForMessages();
         $this->scanMailTemplatesForMessages();
+    }
+
+    /**
+     * Sets all current messages as not found
+     * @return void
+     */
+    public function setMessagesAsNotFound()
+    {
+        Message::query()->update(['found' => 0]);
     }
 
     /**

--- a/controllers/Messages.php
+++ b/controllers/Messages.php
@@ -202,7 +202,8 @@ class Messages extends Controller
                 'id' => $message->id,
                 'code' => $message->code,
                 'from' => $message->forLocale($fromCode),
-                'to' => $toContent
+                'to' => $toContent,
+                'found' => $message->found ? '' : Lang::get('rainlab.translate::lang.messages.not_found'),
             ];
         }
 

--- a/controllers/Messages.php
+++ b/controllers/Messages.php
@@ -74,6 +74,10 @@ class Messages extends Controller
         }
 
         ThemeScanner::scan();
+        
+        if (post('purge_deleted_messages', false)) {
+            Message::where('found', 0)->delete();
+        }
 
         Flash::success(Lang::get('rainlab.translate::lang.messages.scan_messages_success'));
 

--- a/controllers/Messages.php
+++ b/controllers/Messages.php
@@ -1,232 +1,283 @@
-<?php namespace RainLab\Translate\Controllers;
+<?php namespace RainLab\Translate\Models;
 
-use Backend\Behaviors\ImportExportController;
+use Str;
 use Lang;
-use Flash;
-use RainLab\Translate\Models\MessageExport;
-use Request;
-use BackendMenu;
-use Backend\Classes\Controller;
-use RainLab\Translate\Models\Message;
-use RainLab\Translate\Models\Locale;
-use RainLab\Translate\Classes\ThemeScanner;
-use System\Helpers\Cache as CacheHelper;
-use System\Classes\SettingsManager;
+use Model;
+use Cache;
+use Config;
 
 /**
- * Messages Back-end Controller
+ * Message Model
  */
-class Messages extends Controller
+class Message extends Model
 {
-    public $implement = [
-        ImportExportController::class,
-    ];
+    const DEFAULT_LOCALE = 'x';
 
-    public $importExportConfig = 'config_import_export.yaml';
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = 'rainlab_translate_messages';
 
-    public $requiredPermissions = ['rainlab.translate.manage_messages'];
+    /**
+     * @var array Guarded fields
+     */
+    protected $guarded = [];
 
-    protected $hideTranslated = false;
+    /**
+     * @var array List of attribute names which are json encoded and decoded from the database.
+     */
+    protected $jsonable = ['message_data'];
 
-    public function __construct()
+    /**
+     * @var bool Indicates if the model should be timestamped.
+     */
+    public $timestamps = false;
+
+    public static $hasNew = false;
+
+    public static $url;
+
+    public static $locale;
+
+    public static $cache = [];
+
+    /**
+     * Returns the value for the active locale.
+     * @return string
+     */
+    public function getContentAttribute()
     {
-        parent::__construct();
-
-        BackendMenu::setContext('October.System', 'system', 'settings');
-        SettingsManager::setContext('RainLab.Translate', 'messages');
-
-        $this->addJs('/plugins/rainlab/translate/assets/js/messages.js');
-        $this->addCss('/plugins/rainlab/translate/assets/css/messages.css');
-
-        $this->importColumns = MessageExport::getColumns();
-        $this->exportColumns = MessageExport::getColumns();
+        return $this->forLocale(Lang::getLocale());
     }
 
-    public function index()
+    /**
+     * Gets a message for a given locale, or the default.
+     * @param  string $locale
+     * @return string
+     */
+    public function forLocale($locale = null, $default = null)
     {
-        $this->bodyClass = 'slim-container breadcrumb-flush';
-        $this->pageTitle = 'rainlab.translate::lang.messages.title';
-        $this->prepareTable();
-    }
-
-    public function onRefresh()
-    {
-        $this->prepareTable();
-        return ['#messagesContainer' => $this->makePartial('messages')];
-    }
-
-    public function onClearCache()
-    {
-        CacheHelper::clear();
-
-        Flash::success(Lang::get('rainlab.translate::lang.messages.clear_cache_success'));
-    }
-
-    public function onLoadScanMessagesForm()
-    {
-        return $this->makePartial('scan_messages_form');
-    }
-
-    public function onScanMessages()
-    {
-        if (post('purge_messages', false)) {
-            Message::truncate();
+        if ($locale === null) {
+            $locale = self::DEFAULT_LOCALE;
         }
 
-        ThemeScanner::scan();
-
-        Flash::success(Lang::get('rainlab.translate::lang.messages.scan_messages_success'));
-
-        return $this->onRefresh();
-    }
-
-    public function prepareTable()
-    {
-        $fromCode = post('locale_from', null);
-        $toCode = post('locale_to', Locale::getDefault()->code);
-        $this->hideTranslated = post('hide_translated', false);
-
-        /*
-         * Page vars
-         */
-        $this->vars['hideTranslated'] = $this->hideTranslated;
-        $this->vars['defaultLocale'] = Locale::getDefault();
-        $this->vars['locales'] = Locale::all();
-        $this->vars['selectedFrom'] = $selectedFrom = Locale::findByCode($fromCode);
-        $this->vars['selectedTo'] = $selectedTo = Locale::findByCode($toCode);
-
-        /*
-         * Make table config, make default column read only
-         */
-        $config = $this->makeConfig('config_table.yaml');
-
-        if (!$selectedFrom) {
-            $config->columns['from']['readOnly'] = true;
-        }
-        if (!$selectedTo) {
-            $config->columns['to']['readOnly'] = true;
+        if (array_key_exists($locale, $this->message_data)) {
+            return $this->message_data[$locale];
         }
 
-        /*
-         * Make table widget
-         */
-        $widget = $this->makeWidget('Backend\Widgets\Table', $config);
-        $widget->bindToController();
-
-        /*
-         * Populate data
-         */
-        $dataSource = $widget->getDataSource();
-
-        $dataSource->bindEvent('data.getRecords', function($offset, $count) use ($selectedFrom, $selectedTo) {
-            $messages = $this->listMessagesForDatasource([
-                'offset' => $offset,
-                'count' => $count
-            ]);
-
-            return $this->processTableData($messages, $selectedFrom, $selectedTo);
-        });
-
-        $dataSource->bindEvent('data.searchRecords', function($search, $offset, $count) use ($selectedFrom, $selectedTo) {
-            $messages = $this->listMessagesForDatasource([
-                'search' => $search,
-                'offset' => $offset,
-                'count' => $count
-            ]);
-
-            return $this->processTableData($messages, $selectedFrom, $selectedTo);
-        });
-
-        $dataSource->bindEvent('data.getCount', function() {
-            return Message::count();
-        });
-
-        $dataSource->bindEvent('data.updateRecord', function($key, $data) {
-            $message = Message::find($key);
-            $this->updateTableData($message, $data);
-            CacheHelper::clear();
-        });
-
-        $dataSource->bindEvent('data.deleteRecord', function($key) {
-            if ($message = Message::find($key)) {
-                $message->delete();
-            }
-        });
-
-        $this->vars['table'] = $widget;
+        return $default;
     }
 
-    protected function isHideTranslated()
+    /**
+     * Writes a translated message to a locale.
+     * @param  string $locale
+     * @param  string $message
+     * @return void
+     */
+    public function toLocale($locale = null, $message)
     {
-        return post('hide_translated', false);
-    }
-
-    protected function listMessagesForDatasource($options = [])
-    {
-        extract(array_merge([
-            'search' => null,
-            'offset' => null,
-            'count' => null,
-        ], $options));
-
-        $query = Message::orderBy('message_data','asc');
-
-        if ($search) {
-            $query = $query->searchWhere($search, ['message_data']);
-        }
-
-        if ($count) {
-            $query = $query->limit($count)->offset($offset);
-        }
-
-        return $query->get();
-    }
-
-    protected function processTableData($messages, $from, $to)
-    {
-        $fromCode = $from ? $from->code : null;
-        $toCode = $to ? $to->code : null;
-
-        $data = [];
-        foreach ($messages as $message) {
-            $toContent = $message->forLocale($toCode);
-            if ($this->hideTranslated && $toContent) {
-                continue;
-            }
-
-            $data[] = [
-                'id' => $message->id,
-                'code' => $message->code,
-                'from' => $message->forLocale($fromCode),
-                'to' => $toContent
-            ];
-        }
-
-        return $data;
-    }
-
-    protected function updateTableData($message, $data)
-    {
-        if (!$message) {
+        if ($locale === null) {
             return;
         }
 
-        $fromCode = post('locale_from');
-        $toCode = post('locale_to');
+        $data = $this->message_data;
+        $data[$locale] = $message;
 
-        // @todo This should be unified to a single save()
-        if ($fromCode) {
-            $fromValue = array_get($data, 'from');
-            if ($fromValue != $message->forLocale($fromCode)) {
-                $message->toLocale($fromCode, $fromValue);
-            }
+        if (!$message) {
+            unset($data[$locale]);
+        }
+        $this->message_data = $data;
+
+        $this->save();
+    }
+
+    /**
+     * Creates or finds an untranslated message string.
+     * @param  string $messageId
+     * @param  string $locale
+     * @return string
+     */
+    public static function get($messageId, $locale = null)
+    {
+        $locale = $locale ?: self::$locale;
+        if (!$locale) {
+            return $messageId;
         }
 
-        if ($toCode) {
-            $toValue = array_get($data, 'to');
-            if ($toValue != $message->forLocale($toCode)) {
-                $message->toLocale($toCode, $toValue);
-            }
+        $messageCode = self::makeMessageCode($messageId);
+
+        /*
+         * Found in cache
+         */
+        if (array_key_exists($locale . $messageCode, self::$cache)) {
+            return self::$cache[$locale . $messageCode];
         }
+
+        /*
+         * Uncached item
+         */
+        $item = static::firstOrNew([
+            'code' => $messageCode
+        ]);
+
+        /*
+         * Create a default entry
+         */
+        if (!$item->exists) {
+            $data = [static::DEFAULT_LOCALE => $messageId];
+            $item->message_data = $item->message_data ?: $data;
+
+            $item->save();
+        }
+
+        /*
+         * Schedule new cache and go
+         */
+        $msg = $item->forLocale($locale, $messageId);
+        self::$cache[$locale . $messageCode] = $msg;
+        self::$hasNew = true;
+
+        return $msg;
+    }
+
+    /**
+     * Import an array of messages. Only known messages are imported.
+     * @param  array $messages
+     * @param  string $locale
+     * @return void
+     */
+    public static function importMessages($messages, $locale = null)
+    {
+        self::importMessageCodes(array_combine($messages, $messages), $locale);
+    }
+
+    /**
+     * Import an array of messages. Only known messages are imported.
+     * @param  array $messages
+     * @param  string $locale
+     * @return void
+     */
+    public static function importMessageCodes($messages, $locale = null)
+    {
+        if ($locale === null) {
+            $locale = static::DEFAULT_LOCALE;
+        }
+
+        foreach ($messages as $code => $message) {
+            // Ignore empties
+            if (!strlen(trim($message))) {
+                continue;
+            }
+
+            $code = self::makeMessageCode($code);
+
+            $item = static::firstOrNew([
+                'code' => $code,
+            ]);
+
+            // Do not import non-default messages that do not exist
+            if (!$item->exists && $locale != static::DEFAULT_LOCALE) {
+                continue;
+            }
+
+            $messageData = $item->exists || $item->message_data ? $item->message_data : [];
+
+            // Do not overwrite existing translations
+            if (isset($messageData[$locale])) {
+                $item->found = 1;
+                $item->save();
+                continue;
+            }
+
+            $messageData[$locale] = $message;
+
+            $item->message_data = $messageData;
+            $item->found = 1;
+
+            $item->save();
+        }
+    }
+
+    /**
+     * Looks up and translates a message by its string.
+     * @param  string $messageId
+     * @param  array  $params
+     * @param  string $locale
+     * @return string
+     */
+    public static function trans($messageId, $params = [], $locale = null)
+    {
+        $msg = static::get($messageId, $locale);
+
+        $params = array_build($params, function($key, $value){
+            return [':'.$key, $value];
+        });
+
+        $msg = strtr($msg, $params);
+
+        return $msg;
+    }
+
+    /**
+     * Set the caching context, the page url.
+     * @param string $locale
+     * @param string $url
+     */
+    public static function setContext($locale, $url = null)
+    {
+        if (!strlen($url)) {
+            $url = '/';
+        }
+
+        self::$url = $url;
+        self::$locale = $locale;
+
+        if ($cached = Cache::get(self::makeCacheKey())) {
+            self::$cache = (array) $cached;
+        }
+    }
+
+    /**
+     * Save context messages to cache.
+     * @return void
+     */
+    public static function saveToCache()
+    {
+        if (!self::$hasNew || !self::$url || !self::$locale) {
+            return;
+        }
+
+        $expiresAt = now()->addMinutes(Config::get('rainlab.translate::cacheTimeout', 1440));
+        Cache::put(self::makeCacheKey(), self::$cache, $expiresAt);
+    }
+
+    /**
+     * Creates a cache key for storing context messages.
+     * @return string
+     */
+    protected static function makeCacheKey()
+    {
+        return 'translation.'.self::$locale.self::$url;
+    }
+
+    /**
+     * Creates a sterile key for a message.
+     * @param  string $messageId
+     * @return string
+     */
+    protected static function makeMessageCode($messageId)
+    {
+        $separator = '.';
+
+        // Convert all dashes/underscores into separator
+        $messageId = preg_replace('!['.preg_quote('_').'|'.preg_quote('-').']+!u', $separator, $messageId);
+
+        // Remove all characters that are not the separator, letters, numbers, or whitespace.
+        $messageId = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($messageId));
+
+        // Replace all separator characters and whitespace by a single separator
+        $messageId = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $messageId);
+
+        return Str::limit(trim($messageId, $separator), 250);
     }
 }

--- a/controllers/messages/_scan_messages_form.htm
+++ b/controllers/messages/_scan_messages_form.htm
@@ -10,7 +10,7 @@
             <p>
                 <?= e(trans('rainlab.translate::lang.messages.scan_messages_process')) ?>
                 <?= e(trans('rainlab.translate::lang.messages.scan_messages_process_limitations')) ?>
-                
+
             </p>
 
             <div class="form-preview">
@@ -27,6 +27,20 @@
                         </label>
                         <p class="help-block">
                             <?= e(trans('rainlab.translate::lang.messages.scan_messages_purge_help')) ?>
+                        </p>
+                    </div>
+
+                    <div class="checkbox custom-checkbox">
+                        <input
+                            type="checkbox"
+                            name="purge_deleted_messages"
+                            value="1"
+                            id="purgeDeletedMessages">
+                        <label for="purgeDeletedMessages">
+                            <?= e(trans('rainlab.translate::lang.messages.scan_messages_purge_deleted_label')) ?>
+                        </label>
+                        <p class="help-block">
+                            <?= e(trans('rainlab.translate::lang.messages.scan_messages_purge_deleted_help')) ?>
                         </p>
                     </div>
                 </div>

--- a/controllers/messages/_table_headers.htm
+++ b/controllers/messages/_table_headers.htm
@@ -98,3 +98,8 @@
         <?php endif ?>
     </ul>
 </div>
+
+<!-- Found Header -->
+<script type="text/template" id="<?= $this->getId('foundTitle') ?>">
+    <?= e(trans('rainlab.translate::lang.messages.found')) ?> <i class="icon-info-circle" style="cursor: help" title="<?= e(trans('rainlab.translate::lang.messages.found_help')) ?>"></i>
+</script>

--- a/controllers/messages/config_table.yaml
+++ b/controllers/messages/config_table.yaml
@@ -13,3 +13,6 @@ columns:
         title: From
     to:
         title: To
+    found:
+        title: Found
+        width: 100px

--- a/controllers/messages/config_table.yaml
+++ b/controllers/messages/config_table.yaml
@@ -14,5 +14,5 @@ columns:
     to:
         title: To
     found:
-        title: Found
-        width: 100px
+        title: Scan errors
+        width: 150px

--- a/controllers/messages/index.htm
+++ b/controllers/messages/index.htm
@@ -26,7 +26,7 @@
 
 $(document).render(function(){
     $.translateMessages.setTableElement('#<?= $table->getId() ?>')
-    $.translateMessages.setTitleContents('#<?= $this->getId('fromTitle') ?>', '#<?= $this->getId('toTitle') ?>')
+    $.translateMessages.setTitleContents('#<?= $this->getId('fromTitle') ?>', '#<?= $this->getId('foundTitle') ?>', '#<?= $this->getId('foundTitle') ?>')
     $.translateMessages.setToolbarContents('#<?= $this->getId('tableToolbar') ?>')
 })
 

--- a/controllers/messages/index.htm
+++ b/controllers/messages/index.htm
@@ -26,7 +26,7 @@
 
 $(document).render(function(){
     $.translateMessages.setTableElement('#<?= $table->getId() ?>')
-    $.translateMessages.setTitleContents('#<?= $this->getId('fromTitle') ?>', '#<?= $this->getId('foundTitle') ?>', '#<?= $this->getId('foundTitle') ?>')
+    $.translateMessages.setTitleContents('#<?= $this->getId('fromTitle') ?>', '#<?= $this->getId('toTitle') ?>', '#<?= $this->getId('foundTitle') ?>')
     $.translateMessages.setToolbarContents('#<?= $this->getId('tableToolbar') ?>')
 })
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -57,8 +57,8 @@
         'hide_translated' => 'Hide translated',
         'export_messages_link' => 'Export Messages',
         'import_messages_link' => 'Import Messages',
-        'found' => 'Found',
         'not_found' => 'Not found',
-        'found_help' => 'Whether the message was found by the scanner. If empty, that means it was found. If it was not found, this could mean the message was modified or removed.',
+        'found_help' => 'Whether any errors occurred during scanning.',
+        'found_title' => 'Scan errors',
     ],
 ];

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -57,5 +57,8 @@
         'hide_translated' => 'Hide translated',
         'export_messages_link' => 'Export Messages',
         'import_messages_link' => 'Import Messages',
+        'found' => 'Found',
+        'not_found' => 'Not found',
+        'found_help' => 'Whether the message was found by the scanner. If empty, that means it was found. If it was not found, this could mean the message was modified or removed.',
     ],
 ];

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -51,6 +51,8 @@
         'scan_messages_purge_label' => 'Purge all messages first',
         'scan_messages_purge_help' => 'If checked, this will delete all messages, including their translations, before performing the scan.',
         'scan_messages_purge_confirm' => 'Are you sure you want to delete all messages? This cannot be undone!',
+        'scan_messages_purge_deleted_label' => 'Purge missing messages after scan',
+        'scan_messages_purge_deleted_help' => 'If checked, after the scan is done, any messages the scanner did not find, including their translations, will be deleted. This cannot be undone!',
         'hint_translate' => 'Here you can translate messages used on the front-end, the fields will save automatically.',
         'hide_translated' => 'Hide translated',
         'export_messages_link' => 'Export Messages',

--- a/models/Message.php
+++ b/models/Message.php
@@ -183,12 +183,15 @@ class Message extends Model
 
             // Do not overwrite existing translations
             if (isset($messageData[$locale])) {
+                $item->found = 1;
+                $item->save();
                 continue;
             }
 
             $messageData[$locale] = $message;
 
             $item->message_data = $messageData;
+            $item->found = 1;
             $item->save();
         }
     }

--- a/updates/update_messages_table.php
+++ b/updates/update_messages_table.php
@@ -1,0 +1,23 @@
+<?php namespace RainLab\Translate\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class UpdateMessagesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('rainlab_translate_messages', function($table)
+        {
+            $table->boolean('found')->default(1);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('rainlab_translate_messages', function($table)
+        {
+            $table->dropColumn('found');
+        });
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -69,3 +69,7 @@
     - migrate_morphed_indexes.php
 1.6.8: Add support for transOrderBy; Add translatoin support for ThemeData; Update russian localization.
 1.6.9: Clear Static Page menu cache after saving the model; CSS fix for Text/Textarea input fields language selector.
+1.6.10:
+    - Add option to purge deleted messages when scanning messages
+    - Add Scan error column on Messages page
+    - update_messages_table.php


### PR DESCRIPTION
Related bug report: #525 

I've added another checkbox in the scanner window that when checked will purge only the messages that the scanner was unable to find. For the life of me I couldn't figure out how to add a column to the list view to indicate that the string couldn't be found in the project anymore to give the translator an idea which strings can be safely deleted.

~~It is also missing a migration to add a `boolean` column to `rainlab_translate_messages` called `found`. I'm not exactly sure how that should be handled since you need to increment the version.~~