### PR TITLE
Fix docs: translate key missing quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If translated, the text above will appear as whatever language is selected by th
 
 Message or string translation is the conversion of adhoc strings used throughout the site. A message can be translated with parameters.
 
-    {{ site.name|_ }}
+    {{ 'site.name'|_ }}
 
     {{ 'Welcome to our website!'|_ }}
 


### PR DESCRIPTION
Just spent a good hour trying to figure out why the translate key wasn't outputting the translated text. The translate key must be in quotes when calling it inside the translate twig filter. 👍