### PR TITLE
try locale without country before returning default translation

### DIFF
--- a/models/Message.php
+++ b/models/Message.php
@@ -61,6 +61,10 @@ class Message extends Model
             $locale = self::DEFAULT_LOCALE;
         }
 
+        if (!array_key_exists($locale, $this->message_data)) {
+            // extract more generic locale
+            list($locale) = explode('-', $locale);
+        }
         if (array_key_exists($locale, $this->message_data)) {
             return $this->message_data[$locale];
         }

--- a/models/Message.php
+++ b/models/Message.php
@@ -62,9 +62,10 @@ class Message extends Model
         }
 
         if (!array_key_exists($locale, $this->message_data)) {
-            // extract more generic locale
+            // search parent locale (e.g. en-US -> en) before returning default
             list($locale) = explode('-', $locale);
         }
+
         if (array_key_exists($locale, $this->message_data)) {
             return $this->message_data[$locale];
         }


### PR DESCRIPTION
If there is a Message translations for "en" locale and current locale (or requested locale) is "en-us", return translation for "en" before returning fallback translation.