### PR TITLE
Add support for translating RainLab.Pages MenuItem properties

### DIFF
--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -186,10 +186,6 @@ abstract class TranslatableBehavior extends ExtensionBase
      */
     public function getTranslateAttributes($locale)
     {
-        if (!array_key_exists($locale, $this->translatableAttributes)) {
-            $this->loadTranslatableData($locale);
-        }
-
         return array_get($this->translatableAttributes, $locale, []);
     }
 

--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -186,6 +186,10 @@ abstract class TranslatableBehavior extends ExtensionBase
      */
     public function getTranslateAttributes($locale)
     {
+        if (!array_key_exists($locale, $this->translatableAttributes)) {
+            $this->loadTranslatableData($locale);
+        }
+
         return array_get($this->translatableAttributes, $locale, []);
     }
 

--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -261,12 +261,19 @@ trait MLControl
         return false;
     }
 
+    /**
+     * Internal helper for method existence checks.
+     *
+     * @param  object $object
+     * @param  string $method
+     * @return boolean
+     */
     protected function objectMethodExists($object, $method)
     {
         if (method_exists($object, 'methodExists')) {
             return $object->methodExists($method);
-        } else {
-            return method_exists($object, $method);
         }
+
+        return method_exists($object, $method);
     }
 }


### PR DESCRIPTION
Complements https://github.com/rainlab/pages-plugin/pull/445

- changes the MenuItem title/url fields to MLText formwidget
- handle the `pages.menu.referencesGenerated` event to replace MenuItem title/url with their translation (if available)