### PR TITLE
Restore multilingual button position for textarea

### DIFF
--- a/assets/css/multilingual.css
+++ b/assets/css/multilingual.css
@@ -3,7 +3,8 @@
 .field-multilingual .ml-btn:hover {color:#555}
 .field-multilingual.field-multilingual-text .form-control {padding-right:44px}
 .field-multilingual.field-multilingual-text .ml-btn {right:4px;top:50%;margin-top:-44px;height:88px}
-.field-multilingual.field-multilingual-textarea .ml-btn {right:11px;top:5px;text-align:right}
+.field-multilingual.field-multilingual-textarea textarea {padding-right:30px}
+.field-multilingual.field-multilingual-textarea .ml-btn {right:13px;top:5px;width:24px;text-align:right;padding-left:4px}
 .field-multilingual.field-multilingual-textarea .ml-dropdown-menu {top:39px;right:1px}
 .field-multilingual.field-multilingual-richeditor .ml-btn {top:43px;right:25px;text-align:right}
 .field-multilingual.field-multilingual-richeditor .ml-dropdown-menu {top:74px;right:12px}
@@ -18,5 +19,3 @@
 .fancy-layout .form-tabless-fields .field-multilingual .ml-btn:hover {color:#fff}
 .fancy-layout .field-multilingual-text input.form-control {padding-right:44px}
 .help-block.before-field + .field-multilingual.field-multilingual-textarea .ml-btn {top:-41px}
-div[data-control="multilingual"] textarea.form-control.field-textarea {margin-right:26px;padding-right:36px;scrollbar-width:thin}
-div[data-control="multilingual"] textarea.form-control.field-textarea::-webkit-scrollbar {width:0}

--- a/assets/css/multilingual.css
+++ b/assets/css/multilingual.css
@@ -3,8 +3,8 @@
 .field-multilingual .ml-btn:hover {color:#555}
 .field-multilingual.field-multilingual-text .form-control {padding-right:44px}
 .field-multilingual.field-multilingual-text .ml-btn {right:4px;top:50%;margin-top:-44px;height:88px}
-.field-multilingual.field-multilingual-textarea .ml-btn {right:11px;top:-29px;text-align:right}
-.field-multilingual.field-multilingual-textarea .ml-dropdown-menu {top:1px;right:1px}
+.field-multilingual.field-multilingual-textarea .ml-btn {right:11px;top:5px;text-align:right}
+.field-multilingual.field-multilingual-textarea .ml-dropdown-menu {top:39px;right:1px}
 .field-multilingual.field-multilingual-richeditor .ml-btn {top:43px;right:25px;text-align:right}
 .field-multilingual.field-multilingual-richeditor .ml-dropdown-menu {top:74px;right:12px}
 .field-multilingual.field-multilingual-markdowneditor .ml-btn {top:43px;right:25px;text-align:right}
@@ -18,3 +18,5 @@
 .fancy-layout .form-tabless-fields .field-multilingual .ml-btn:hover {color:#fff}
 .fancy-layout .field-multilingual-text input.form-control {padding-right:44px}
 .help-block.before-field + .field-multilingual.field-multilingual-textarea .ml-btn {top:-41px}
+div[data-control="multilingual"] textarea.form-control.field-textarea {margin-right:26px;padding-right:36px;scrollbar-width:thin}
+div[data-control="multilingual"] textarea.form-control.field-textarea::-webkit-scrollbar {width:0}

--- a/assets/less/multilingual.less
+++ b/assets/less/multilingual.less
@@ -36,10 +36,17 @@
     }
 
     &.field-multilingual-textarea {
+        textarea {
+            // increase padding on the right so that the textarea content does not overlap with the language button
+            padding-right: 30px;
+        }
+
         .ml-btn {
-            right: 11px;
+            right: 13px;
             top: 5px;
+            width: 24px;
             text-align: right;
+            padding-left: 4px;
         }
 
         .ml-dropdown-menu {
@@ -123,15 +130,3 @@
         top: -41px;
     }
 }
-
-div[data-control="multilingual"] textarea.form-control.field-textarea {
-    // increase padding on the right so that the textarea content does not overlap with the language button
-    padding-right: 36px;
-
-    // remove scrollbars to prevent interference with the language button
-    scrollbar-width: thin;
-    &::-webkit-scrollbar {
-        width: 0;
-    }
-}
-

--- a/assets/less/multilingual.less
+++ b/assets/less/multilingual.less
@@ -38,12 +38,12 @@
     &.field-multilingual-textarea {
         .ml-btn {
             right: 11px;
-            top: -29px;
+            top: 5px;
             text-align: right;
         }
 
         .ml-dropdown-menu {
-            top: 1px;
+            top: 39px;
             right: 1px;
         }
     }
@@ -123,3 +123,15 @@
         top: -41px;
     }
 }
+
+div[data-control="multilingual"] textarea.form-control.field-textarea {
+    // increase padding on the right so that the textarea content does not overlap with the language button
+    padding-right: 36px;
+
+    // remove scrollbars to prevent interference with the language button
+    scrollbar-width: thin;
+    &::-webkit-scrollbar {
+        width: 0;
+    }
+}
+


### PR DESCRIPTION
the previously introduced change was overlapping with other input fields when the textarea did not have a label on top.