### PR TITLE
Faster version of transWhere

### DIFF
--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -46,6 +46,8 @@ class TranslatableModel extends TranslatableBehavior
             $locale = $this->translatableContext;
         }
 
+        // Separate query into two separate queries for improved performance
+        // @see https://github.com/rainlab/translate-plugin/pull/623
         $translateIndexes = DB::table('rainlab_translate_indexes')
             ->where('rainlab_translate_indexes.model_type', '=', $this->getClass())
             ->where('rainlab_translate_indexes.locale', '=', $locale)
@@ -53,7 +55,7 @@ class TranslatableModel extends TranslatableBehavior
             ->where('rainlab_translate_indexes.value', $operator, $value)
             ->pluck('model_id');
 
-        if($translateIndexes->count()) {
+        if ($translateIndexes->count()) {
             $query->whereIn($this->model->getQualifiedKeyName(), $translateIndexes);
         } else {
             $query->where($index, $operator, $value);

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -48,7 +48,7 @@ class TranslatableModel extends TranslatableBehavior
 
         // Separate query into two separate queries for improved performance
         // @see https://github.com/rainlab/translate-plugin/pull/623
-        $translateIndexes = DB::table('rainlab_translate_indexes')
+        $translateIndexes = Db::table('rainlab_translate_indexes')
             ->where('rainlab_translate_indexes.model_type', '=', $this->getClass())
             ->where('rainlab_translate_indexes.locale', '=', $locale)
             ->where('rainlab_translate_indexes.item', $index)

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -42,19 +42,22 @@ class TranslatableModel extends TranslatableBehavior
      */
     public function scopeTransWhere($query, $index, $value, $locale = null, $operator = '=')
     {
-        $query->select($this->model->getTable().'.*');
+        if (!$locale) {
+            $locale = $this->translatableContext;
+        }
 
-        $query->where(function($q) use ($index, $value, $operator) {
-            $q->where($this->model->getTable().'.'.$index, $operator, $value);
-            $q->orWhere(function($q) use ($index, $value, $operator) {
-                $q
-                    ->where('rainlab_translate_indexes.item', $index)
-                    ->where('rainlab_translate_indexes.value', $operator, $value)
-                ;
-            });
-        });
+        $translateIndexes = DB::table('rainlab_translate_indexes')
+            ->where('rainlab_translate_indexes.model_type', '=', $this->getClass())
+            ->where('rainlab_translate_indexes.locale', '=', $locale)
+            ->where('rainlab_translate_indexes.item', $index)
+            ->where('rainlab_translate_indexes.value', $operator, $value)
+            ->pluck('model_id');
 
-        $this->joinTranslateIndexesTable($query, $locale);
+        if($translateIndexes->count()) {
+            $query->whereIn($this->model->getQualifiedKeyName(), $translateIndexes);
+        } else {
+            $query->where($index, $operator, $value);
+        }
 
         return $query;
     }


### PR DESCRIPTION
This PR is an alternative version of https://github.com/rainlab/translate-plugin/pull/586

Instead of creating a separate method that has a different behavior to the original implementation, I managed to fix ``transWhere`` itself by utilizing 2 queries instead of the slow orWhere clause. This implementation also preserves the fallback functionality.

I made some tests on my project (originally discussed here: https://github.com/rainlab/translate-plugin/issues/581) - now I have 2 queries that execute in ~ 5 ms instead of a single 60 second query. The improvement is significant.

Comments are welcome.