### PR TITLE
Change self::makeCacheKey and self::makeMessageCode to static::

### DIFF
--- a/models/Message.php
+++ b/models/Message.php
@@ -109,7 +109,7 @@ class Message extends Model
             return $messageId;
         }
 
-        $messageCode = self::makeMessageCode($messageId);
+        $messageCode = static::makeMessageCode($messageId);
 
         /*
          * Found in cache
@@ -175,7 +175,7 @@ class Message extends Model
                 continue;
             }
 
-            $code = self::makeMessageCode($code);
+            $code = static::makeMessageCode($code);
 
             $item = static::firstOrNew([
                 'code' => $code
@@ -260,7 +260,7 @@ class Message extends Model
         self::$url = $url;
         self::$locale = $locale;
 
-        if ($cached = Cache::get(self::makeCacheKey())) {
+        if ($cached = Cache::get(static::makeCacheKey())) {
             self::$cache = (array) $cached;
         }
     }
@@ -276,7 +276,7 @@ class Message extends Model
         }
 
         $expiresAt = now()->addMinutes(Config::get('rainlab.translate::cacheTimeout', 1440));
-        Cache::put(self::makeCacheKey(), self::$cache, $expiresAt);
+        Cache::put(static::makeCacheKey(), self::$cache, $expiresAt);
     }
 
     /**


### PR DESCRIPTION
Change calling protected method makeCacheKey and makeMessageCode with static, to enable call override method from custom Message class.
example:
class Message extends \RainLab\Translate\Models\Message
{
    /**
     * @param string $messageId
     * @return string
     */
    protected static function makeMessageCode($messageId)
    {
        return $messageId;
    }
}