### PR TITLE
Adding noFallbackLocale inverse method

### DIFF
--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -121,6 +121,17 @@ abstract class TranslatableBehavior extends ExtensionBase
 
         return $this->model;
     }
+    
+    /**
+     * Enables translation fallback locale.
+     * @return self
+     */
+    public function withFallbackLocale()
+    {
+        $this->translatableUseFallback = true;
+
+        return $this->model;
+    }
 
     /**
      * Returns a translated attribute value.


### PR DESCRIPTION
adding withFallbackLocale to inverse noFallbackLocale.

Useful when iteration over multiple locales and reuse the model.

```php
// Translated locale links
if (class_exists('RainLab\Translate\Behaviors\TranslatableModel')) {
    $currentLocale = (\RainLab\Translate\Classes\Translator::instance())->getLocale();
    $translations = [];

    foreach (\RainLab\Translate\Models\Locale::listEnabled() as $code => $locale) {
        if($currentLocale === $code) continue;

        $post->noFallbackLocale()->lang($code);
        if (empty($post->title) || empty($post->slug) ) continue;

        $post->translateContext($code);
        if (!$category) {
            $category = $post->categories->first();
        }

        $category->translateContext($code);
        $translations[$code] =  [
            'code' => $code,
            'name' => $locale,
            'slug' => $post->slug,
            'url' => $this->rewriteTranslatablePageUrl([
                'category' => $category->slug,
                'slug' => $post->slug
            ], $code),
            'title' => $post->title
        ];
    }

    $this->page['post_available_locales'] = $translations;
    $post->withFallbackLocale()->translateContext($currentLocale);
}
```