### PR TITLE
Update Locale.php

### DIFF
--- a/models/Locale.php
+++ b/models/Locale.php
@@ -214,5 +214,8 @@ class Locale extends Model
     {
         Cache::forget('rainlab.translate.locales');
         Cache::forget('rainlab.translate.defaultLocale');
+        self::$cacheListEnabled = null;
+        self::$cacheListAvailable = null;
+        self::$cacheByCode = null;
     }
 }


### PR DESCRIPTION
Hi Guys,

I think that when clearing the cache, we should not forget about the local cache. I know it's very uncommon to have problems with it but I had while running tests on translatable fields. I was not able to add a new locale and test values returned while running unit tests because I was always getting the cached locales from these static properties. After I clear the cache using this method, everything works as expected.

Regards,

Tomasz Strojny