### PR TITLE
rainlab_translate_attributes deletion on afterDelete

### DIFF
--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -34,7 +34,7 @@ class TranslatableModel extends TranslatableBehavior
         }
 
         // Clean up indexes when this model is deleted
-        $model->bindEvent('model.beforeDelete', function() use ($model) {
+        $model->bindEvent('model.afterDelete', function() use ($model) {
             Db::table('rainlab_translate_attributes')
                 ->where('model_id', $model->getKey())
                 ->where('model_type', get_class($model))


### PR DESCRIPTION
This change gives an opportunity  of doing something before rainlab_translate_attributes are deleted