### PR TITLE
Fix for parent theme not getting scanned for messages, except when the child theme configuration throws an exception

### DIFF
--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -83,7 +83,9 @@ class ThemeScanner
             $parentTheme = $theme->getParentTheme();
 
             try {
-                $this->scanThemeConfigForMessagesInternal($theme);
+                if (!$this->scanThemeConfigForMessagesInternal($theme)) {
+                    $this->scanThemeConfigForMessagesInternal($parentTheme);
+                }
             }
             catch (Exception $ex) {
                 $this->scanThemeConfigForMessagesInternal($parentTheme);
@@ -102,7 +104,7 @@ class ThemeScanner
         $config = $theme->getConfigArray('translate');
 
         if (!count($config)) {
-            return;
+            return false;
         }
 
         $translator = Translator::instance();


### PR DESCRIPTION
In a parent/child theme setup, the parent theme nevers gets scanned for messages, except when the child theme supplies an invalid configuration (like non-existant file or syntax error in the YAML file - something that throws an exception).

This PR lets scanThemeConfigForMessagesInternal return false if no configuration value is present,
so the part of ThemeScanner.php that handles parent theme translations can check for false and try the parent theme.

If a translate config key is present in the child, only the child configuration gets used, as intended.