### PR TITLE
Handle default locale in transWhereNoFallback

### DIFF
--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -89,6 +89,11 @@ class TranslatableModel extends TranslatableBehavior
      */
     public function scopeTransWhereNoFallback($query, $index, $value, $locale = null, $operator = '=')
     {
+        // Ignore translatable indexes in default locale context
+        if(($locale ?: $this->translatableContext) === $this->translatableDefault) {
+            return $query->where($index, $operator, $value);
+        }
+        
         return $this->transWhereInternal($query, $index, $value, [
             'locale' => $locale,
             'operator' => $operator,


### PR DESCRIPTION
This PR attempts to solve the issue of using ``transWhereNoFallback`` in the default locale. In that case, we don't want to query translatable indexes, since we store the default locale in the main table.

Further discussion: https://github.com/rainlab/translate-plugin/pull/623