### PR TITLE
Remove mltext reference

### DIFF
--- a/classes/EventRegistry.php
+++ b/classes/EventRegistry.php
@@ -119,7 +119,7 @@ class EventRegistry
 
             // Replace specified fields with multilingual versions
             foreach ($fieldsToTranslate as $fieldName) {
-                $widget->fields[$fieldName]['type'] = 'mltext';
+                $widget->fields[$fieldName]['translatable'] = true;
 
                 foreach ($availableLocales as $code => $locale) {
                     if (!$defaultLocale || $defaultLocale->code === $code) {


### PR DESCRIPTION
Fixed error ``SystemException: The partial '_field_mltext' is not found`` when opening Pages->Menus.

Translations in Page plugin of course don't work yet, but with this PR it is at least possible to edit the default language.