### PR TITLE
Do not add translatable fields to nested widgets

### DIFF
--- a/classes/EventPluginRegistry.php
+++ b/classes/EventPluginRegistry.php
@@ -62,6 +62,10 @@ class EventPluginRegistry
             if (!PluginManager::instance()->exists('RainLab.Pages')) {
                 return;
             }
+            
+            if ($widget->isNested) {
+                return;
+            }
 
             $fieldsToTranslate = [];
             if ($widget->model instanceof \RainLab\Pages\Classes\Page) {


### PR DESCRIPTION
If we have a custom repeater on a Page, each item gets a ``viewBag[url]`` text field added. This PR prevents that from happening.