### PR TITLE
Make importMessages public

### DIFF
--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -220,7 +220,7 @@ class ThemeScanner
      * importMessages will import scanned messages, use withKeys if the messages
      * also contain their translation key, e.g [my_code => My Code]
      */
-    protected function importMessages($messages, $locale = null, $withKeys = false)
+    public function importMessages($messages, $locale = null, $withKeys = false)
     {
         if (!$withKeys) {
             $messages = array_combine($messages, $messages);


### PR DESCRIPTION
I believe this is needed if we want to add custom messages to the scanner:

```php
Event::listen('rainlab.translate.themeScanner.afterScan', function(ThemeScanner $scanner) {
    $scanner->importMessages(['Custom message 1', 'Custom message 2']);
});
```