### PR TITLE
Use Site context to get the current site

### DIFF
--- a/classes/Locale.php
+++ b/classes/Locale.php
@@ -50,9 +50,7 @@ class Locale extends ElementBase
      */
     public static function getSiteLocaleFromContext()
     {
-        $site = App::runningInBackend()
-            ? Site::getEditSite()
-            : Site::getActiveSite();
+        $site = Site::getSiteFromContext();
 
         return $site ? $site->hard_locale : '';
     }


### PR DESCRIPTION
This fixes issue #734 , allowing the plugins to change the Site context to send an email, generate a pdf, etc in a language different than the current one:

```
$siteId = Site::listEnabled()->where('locale', $newLocale)->first()->id;
Site::withContext($siteId, function () use ($sendTo, $template) {
    Mail::sendTo($sendTo, $template);
});
```