### PR TITLE
Performance. Change column 'model_id' to int. Change index.

### DIFF
--- a/updates/update_attributes_change_index_model.php
+++ b/updates/update_attributes_change_index_model.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Aerotur\Nemo\Updates;
+
+use DB;
+use Log;
+use October\Rain\Database\Updates\Migration;
+use Schema;
+
+class UpdateAttributesCahngeIndexModel extends Migration
+{
+    public function up()
+    {
+        // Check if there are any non-numeric values
+        $invalidRows = DB::table('rainlab_translate_attributes')
+            ->whereNotNull('model_id')
+            ->where('model_id', '!=', '')
+            ->whereRaw("model_id REGEXP '[^0-9]'")
+            ->count();
+
+        if ($invalidRows > 0) {
+            $message = "Found $invalidRows records with non-numeric values in column 'model_id'. Migration will not be applied.";
+            Log::warning($message);
+            return ;
+        }
+        Schema::table('rainlab_translate_attributes', function ($table) {
+            $table->dropIndex(['model_type']);
+            $table->dropIndex(['model_id']);
+            $table->bigInteger('model_id')->nullable(false)->change();
+            $table->index(['model_type', 'model_id']);
+        });
+    }
+
+    public function down()
+    {
+        $modelIdType = Schema::getColumnType('rainlab_translate_attributes', 'model_id');
+        if ($modelIdType === 'bigint') {
+            Schema::table('rainlab_translate_attributes', function ($table) {
+                $table->dropIndex(['model_type', 'model_id']);
+                $table->string('model_id')->nullable()->change();
+                $table->index(['model_id']);
+                $table->index(['model_type']);
+            });
+        }
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -97,3 +97,6 @@ v1.10.5: Fixes media finder when only 1 locale is available
 v1.11.0: Update to latest Media Finder changes in October v2.2
 v1.11.1: Improve support with October v3.0
 v1.12.0: Adds scopeTransWhereNoFallback method
+v1.12.1:
+    - Performance. Change column 'model_id' to int. Change index, create combine index ['model_type', 'model_id'] for rainlab_translate_attributes
+    - update_attributes_change_index_model.php


### PR DESCRIPTION
The current implementation with integer ID models causes inefficient index usage where only the model_type index is employed, leading to excessive row scanning. Suggested solution: modify the model_id data type and implement a compound index.
![image](https://github.com/user-attachments/assets/ff750c40-da4d-42d9-af11-d06ebd7ca634)

After
![image](https://github.com/user-attachments/assets/d408f641-b1e3-4edd-a763-58cc9206097e)
